### PR TITLE
Fix markup of the install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ Is your Git repository bursting at the seams?
 
 2.  Install `git-sizer`. Either:
 
-    a.  Install a released version of `git-sizer` (recommended):
+    a. Install a released version of `git-sizer` (recommended):
 
-        *   Go to [the releases page](https://github.com/github/git-sizer/releases) and download the ZIP file corresponding to your platform.
+       *   Go to [the releases page](https://github.com/github/git-sizer/releases) and download the ZIP file corresponding to your platform.
 
-        *   Unzip the file.
+       *   Unzip the file.
 
-        *   Move the executable file (`git-sizer` or `git-sizer.exe`) into your `PATH`.
+       *   Move the executable file (`git-sizer` or `git-sizer.exe`) into your `PATH`.
 
-    b.  Build and install from source. See the instructions in [`docs/BUILDING.md`](docs/BUILDING.md).
+    b. Build and install from source. See the instructions in [`docs/BUILDING.md`](docs/BUILDING.md).
 
 3.  Change to the directory containing the Git repository that you'd like to analyze, then run
 


### PR DESCRIPTION
A nested list is much better than a code block containing some markdown syntax.