### PR TITLE
NewRepository: don't join paths if `gitDir` is already absolute

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -90,7 +90,10 @@ func NewRepository(path string) (*Repository, error) {
 			return nil, err
 		}
 	}
-	gitDir := filepath.Join(path, string(bytes.TrimSpace(out)))
+	gitDir := string(bytes.TrimSpace(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(path, gitDir)
+	}
 	repo := &Repository{
 		path: gitDir,
 	}

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -21,9 +21,7 @@ import (
 func TestExec(t *testing.T) {
 	cmd := exec.Command("bin/git-sizer")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Errorf("command failed (%s); output: %#v", err, string(output))
-	}
+	assert.NoErrorf(t, err, "command failed; output: %#v", string(output))
 }
 
 func gitCommand(t *testing.T, repo *git.Repository, args ...string) *exec.Cmd {


### PR DESCRIPTION
If the output of `git -C path rev-parse --git-dir` is already an absolute path (e.g., if `git-sizer` is run from within a subdirectory of a working copy), then it is incorrect to call `filepath.Join()` because that function doesn't treat absolute paths specially. So check `filepath.IsAbs()` first, and only call `filepath.Join()` if the path is not already absolute.

Fixes #10.
