### PR TITLE
Ignore the vendored go (if any)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.gopath
 /bin
 /releases
+/vendor/go1.*


### PR DESCRIPTION
Adjust `.gitignore` to ignore the vendored go toolchain, if it exists.
