### PR TITLE
Don't include the root tree in `MaxPathDepth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ Is your Git repository bursting at the seams?
 
 ## Getting started
 
-1.  Make sure that you have the [Git command-line client](https://git-scm.com/) installed, **version >= 2.6**. NOTE: `git-sizer` invokes `git` commands to examine the contents of your repository, so **it is required that the `git` command be in your `PATH`** when you run `git-sizer`. 
+1.  Make sure that you have the [Git command-line client](https://git-scm.com/) installed, **version >= 2.6**. NOTE: `git-sizer` invokes `git` commands to examine the contents of your repository, so **it is required that the `git` command be in your `PATH`** when you run `git-sizer`.
 
 2.  Install `git-sizer`. Either:
 
     a. Install a released version of `git-sizer`(recommended):
-       1. Go to [the releases page](https://github.com/github/git-sizer/releases) and download the ZIP file corresponding to your platform. 
-       2. Unzip the file. 
-       3. Move the executable file (`git-sizer` or `git-sizer.exe`) into your `PATH`.   
-       
+       1. Go to [the releases page](https://github.com/github/git-sizer/releases) and download the ZIP file corresponding to your platform.
+       2. Unzip the file.
+       3. Move the executable file (`git-sizer` or `git-sizer.exe`) into your `PATH`.
+
     b. Build and install from source. See the instructions in [`docs/BUILDING.md`](docs/BUILDING.md).
 
 3.  Change to the directory containing the Git repository that you'd like to analyze, then run

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Processing references: 539
 | * Number of symlinks    [10] |    40     |                                |
 | * Number of submodules       |     0     |                                |
 
-[1]  91cc53b0c78596a73fa708cceb7313e7168bb146 (91cc53b0c78596a73fa708cceb7313e7168bb146)
-[2]  2cde51fbd0f310c8a2c5f977e665c0ac3945b46d (2cde51fbd0f310c8a2c5f977e665c0ac3945b46d)
+[1]  91cc53b0c78596a73fa708cceb7313e7168bb146
+[2]  2cde51fbd0f310c8a2c5f977e665c0ac3945b46d
 [3]  4f86eed5893207aca2c2da86b35b38f2e1ec1fc8 (refs/heads/master:arch/arm/boot/dts)
 [4]  a02b6794337286bc12c907c33d5d75537c240bd0 (refs/heads/master:drivers/gpu/drm/amd/include/asic_reg/vega10/NBIO/nbio_6_1_sh_mask.h)
 [5]  5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c (refs/tags/v2.6.11)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Processing references: 539
 |                              |           |                                |
 | Biggest checkouts            |           |                                |
 | * Number of directories  [6] |  4.38 k   | **                             |
-| * Maximum path depth     [7] |    14     | *                              |
+| * Maximum path depth     [7] |    13     | *                              |
 | * Maximum path length    [8] |   134 B   | *                              |
 | * Number of files        [9] |  62.3 k   | *                              |
 | * Total size of files    [9] |   747 MiB |                                |

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -190,7 +190,7 @@ func TestBomb(t *testing.T) {
 
 	assert.Equal(counts.Count32(1), h.ReferenceCount, "reference count")
 
-	assert.Equal(counts.Count32(11), h.MaxPathDepth, "max path depth")
+	assert.Equal(counts.Count32(10), h.MaxPathDepth, "max path depth")
 	assert.Equal("refs/heads/master^{tree}", h.MaxPathDepthTree.Path(), "max path depth tree")
 	assert.Equal(counts.Count32(29), h.MaxPathLength, "max path length")
 	assert.Equal("refs/heads/master^{tree}", h.MaxPathLengthTree.Path(), "max path length tree")
@@ -272,10 +272,11 @@ func TestFromSubdir(t *testing.T) {
 
 	repo2, err := git.NewRepository(filepath.Join(path, "subdir"))
 	require.NoError(t, err, "creating Repository object in subdirectory")
-	_, err = sizes.ScanRepositoryUsingGraph(
+	h, err := sizes.ScanRepositoryUsingGraph(
 		repo2, git.AllReferencesFilter, sizes.NameStyleNone, false,
 	)
 	require.NoError(t, err, "scanning repository")
+	assert.Equal(t, counts.Count32(2), h.MaxPathDepth, "max path depth")
 }
 
 func TestSubmodule(t *testing.T) {

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -609,9 +609,6 @@ func (r *treeRecord) initialize(g *Graph, oid git.OID, tree *git.Tree) error {
 
 func (r *treeRecord) maybeFinalize(g *Graph) {
 	if r.pending == 0 {
-		// Add one for this tree itself:
-		r.size.MaxPathDepth.Increment(1)
-
 		g.finalizeTreeSize(r.oid, r.size, r.objectSize, r.entryCount)
 		for _, listener := range r.listeners {
 			listener(r.size)

--- a/sizes/sizes.go
+++ b/sizes/sizes.go
@@ -17,7 +17,7 @@ type BlobSize struct {
 
 type TreeSize struct {
 	// The maximum depth of trees and blobs starting at this object
-	// (including this object).
+	// (not including this object).
 	MaxPathDepth counts.Count32 `json:"max_path_depth"`
 
 	// The maximum length of any path relative to this object, in
@@ -41,7 +41,7 @@ type TreeSize struct {
 }
 
 func (s *TreeSize) addDescendent(filename string, s2 TreeSize) {
-	s.MaxPathDepth.AdjustMaxIfNecessary(s2.MaxPathDepth)
+	s.MaxPathDepth.AdjustMaxIfNecessary(s2.MaxPathDepth.Plus(1))
 	if s2.MaxPathLength > 0 {
 		s.MaxPathLength.AdjustMaxIfNecessary(
 			(counts.NewCount32(uint64(len(filename))) + 1).Plus(s2.MaxPathLength),
@@ -164,7 +164,7 @@ type HistorySize struct {
 	// attribute is maximized separately).
 
 	// The maximum depth of trees and blobs starting at this object
-	// (including this object).
+	// (not including this object).
 	MaxPathDepth counts.Count32 `json:"max_path_depth"`
 
 	// The tree with the maximum path depth.


### PR DESCRIPTION
It is more natural to define the length of a relative path `foo/bar/baz.txt` as 3 rather than 4, so tweak the code to do so. (The old code included the root tree in the count, but that's relatively invisible to the user.) Update the README accordingly, and make a couple of other minor cleanups in that file.
