### PR TITLE
sizes: lower max tree entries threshold to 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Processing references: 539
 |   * Maximum size         [1] |  72.7 KiB | *                              |
 |   * Maximum parents      [2] |    66     | ******                         |
 | * Trees                      |           |                                |
-|   * Maximum entries      [3] |  1.68 k   |                                |
+|   * Maximum entries      [3] |  1.68 k   | *                              |
 | * Blobs                      |           |                                |
 |   * Maximum size         [4] |  13.5 MiB | *                              |
 |                              |           |                                |

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -369,7 +369,7 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 				),
 
 				S("Trees",
-					I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, counts.MetricPrefixes, " ", 2.5e3),
+					I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, counts.MetricPrefixes, " ", 1000),
 				),
 
 				S("Blobs",


### PR DESCRIPTION
Warn the user with one star if a tree has more than 1000 entries and
warn the user with exclamation points after 30k entries.

Reasons:

(1) GitHub truncates directories with more than 1000 entries on the
    website and consequently the content would be harder to discover.

(2) The default Windows file system NTFS might experience performance
    issues if individual directories contain more than 50k files [1].
    Let's warn the user way before this known threshold.

[1] https://support.microsoft.com/en-us/help/2539403/system-may-pause-while-accessing-large-ntfs-folder

---

Truncated example on GitHub: https://github.com/torvalds/linux/tree/master/arch/arm/boot/dts