### PR TITLE
Disable replace references and grafts; require a non-shallow clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Is your Git repository bursting at the seams?
 
     b. Build and install from source. See the instructions in [`docs/BUILDING.md`](docs/BUILDING.md).
 
-3.  Change to the directory containing the Git repository that you'd like to analyze, then run
+3.  Change to the directory containing a full, non-shallow clone of the Git repository that you'd like to analyze. Then run
 
         git sizer [<option>...]
 

--- a/git/git.go
+++ b/git/git.go
@@ -64,6 +64,17 @@ type Repository struct {
 	path string
 }
 
+// smartJoin returns the path that can be described as `relPath`
+// relative to `path`, given that `path` is either absolute or is
+// relative to the current directory.
+func smartJoin(path, relPath string) string {
+	if filepath.IsAbs(relPath) {
+		return relPath
+	} else {
+		return filepath.Join(path, relPath)
+	}
+}
+
 func NewRepository(path string) (*Repository, error) {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
 	out, err := cmd.Output()
@@ -87,10 +98,7 @@ func NewRepository(path string) (*Repository, error) {
 			return nil, err
 		}
 	}
-	gitDir := string(bytes.TrimSpace(out))
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(path, gitDir)
-	}
+	gitDir := smartJoin(path, string(bytes.TrimSpace(out)))
 	repo := &Repository{
 		path: gitDir,
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -97,9 +97,21 @@ func NewRepository(path string) (*Repository, error) {
 	return repo, nil
 }
 
-func (repo *Repository) gitCommand(args ...string) *exec.Cmd {
+func (repo *Repository) gitCommand(callerArgs ...string) *exec.Cmd {
+	// Disable replace references when running our commands:
+	args := []string{"--no-replace-objects"}
+
+	args = append(args, callerArgs...)
+
 	cmd := exec.Command("git", args...)
-	cmd.Env = append(os.Environ(), "GIT_DIR="+repo.path)
+
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_DIR="+repo.path,
+		// Disable grafts when running our commands:
+		"GIT_GRAFT_FILE="+os.DevNull,
+	)
+
 	return cmd
 }
 


### PR DESCRIPTION
`git-sizer` needs to iterate over the whole history, and the iteration has to be in the correct order. This means that

* `git-sizer` can get confused by replace references or grafts. So disable those when running git commands.
* `git-sizer` can't run within a shallow clone. So if that situation is detected, emit an error and refuse to run.

@bharrat, @jeremywrowe, @larsxschneider, @asheiduk: does this change fix your problems?

Fixes #28.
