### PR TITLE
Add a `--version` option to display the version of `git-sizer`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ export GOPATH
 GO := $(CURDIR)/script/go
 GOFMT := $(CURDIR)/script/gofmt
 
-GO_LDFLAGS := -X main.BuildVersion=$(shell git rev-parse HEAD)
-GO_LDFLAGS += -X main.BuildDescribe=$(shell git describe --tags --always --dirty)
+GO_LDFLAGS := -X main.BuildVersion=$(shell git describe --tags --always --dirty || echo unknown)
 GOFLAGS := -ldflags "$(GO_LDFLAGS)"
 
 ifdef USE_ISATTY
@@ -52,7 +51,8 @@ define PLATFORM_template =
 .PHONY: bin/git-sizer-$(1)-$(2)$(3)
 bin/git-sizer-$(1)-$(2)$(3):
 	mkdir -p bin
-	cd $$(GOPATH)/src/$$(PACKAGE) && GOOS=$(1) GOARCH=$(2) $$(GO) build $$(GOFLAGS) -o $$(ROOTDIR)/$$@ $$(PACKAGE)
+	cd $$(GOPATH)/src/$$(PACKAGE) && \
+		GOOS=$(1) GOARCH=$(2) $$(GO) build $$(GOFLAGS) -ldflags "-X main.ReleaseVersion=$$(VERSION)" -o $$(ROOTDIR)/$$@ $$(PACKAGE)
 common-platforms: bin/git-sizer-$(1)-$(2)$(3)
 
 # Note that releases don't include code from vendor (they're only used

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -16,6 +16,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var ReleaseVersion string
+var BuildVersion string
+
 type NegatedBoolValue struct {
 	value *bool
 }
@@ -59,6 +62,7 @@ func mainImplementation() error {
 	var jsonOutput bool
 	var threshold sizes.Threshold = 1
 	var progress bool
+	var version bool
 
 	pflag.BoolVar(&processBranches, "branches", false, "process all branches")
 	pflag.BoolVar(&processTags, "tags", false, "process all tags")
@@ -97,6 +101,7 @@ func mainImplementation() error {
 		atty = false
 	}
 	pflag.BoolVar(&progress, "progress", atty, "report progress to stderr")
+	pflag.BoolVar(&version, "version", false, "report the git-sizer version number")
 	pflag.Var(&NegatedBoolValue{&progress}, "no-progress", "suppress progress output")
 	pflag.Lookup("no-progress").NoOptDefVal = "true"
 
@@ -114,6 +119,15 @@ func mainImplementation() error {
 		}
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if version {
+		if ReleaseVersion != "" {
+			fmt.Printf("git-sizer release %s\n", ReleaseVersion)
+		} else {
+			fmt.Printf("git-sizer build %s\n", BuildVersion)
+		}
+		return nil
 	}
 
 	args := pflag.Args()


### PR DESCRIPTION
If it is a release version, display something like

    git-sizer release 1.2.0

If it is a non-release version, display something like

    git-sizer build v1.1.0-12-g11bf55a-dirty

It turns out that part of the infrastructure had already been cargo-culted into the `Makefile` :smile: but it had to be wired up.

Fixes #36

/cc @JayAndCatchFire, who requested this feature.
