### PR TITLE
Don't consider a "maximum tag depth" of 1 to be concerning

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Processing references: 539
 |                              |           |                                |
 | History structure            |           |                                |
 | * Maximum history depth      |   136 k   |                                |
-| * Maximum tag depth      [5] |     1     | *                              |
+| * Maximum tag depth      [5] |     1     |                                |
 |                              |           |                                |
 | Biggest checkouts            |           |                                |
 | * Number of directories  [6] |  4.38 k   | **                             |

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -379,7 +379,7 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 
 			S("History structure",
 				I("Maximum history depth", nil, s.MaxHistoryDepth, counts.MetricPrefixes, " ", 500e3),
-				I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, counts.MetricPrefixes, " ", 1),
+				I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, counts.MetricPrefixes, " ", 1.001),
 			),
 
 			S("Biggest checkouts",


### PR DESCRIPTION
Every tag has at least a tag depth of 1, so there's no need to flag it as a reason for concern. This change is done a bit kludgily, by changing the scale factor for this statistic from 1 to 1.001, but it has the desired effect of subtracting one from the number of stars computed for any reasonable tag depth.

Unfortunately, we don't have any tests yet that the right number of stars is emitted, but I've tested this manually.

Fixes #38.
