### PR TITLE
Suppress the warning that "info/grafts" is deprecated

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -120,8 +120,15 @@ func NewRepository(path string) (*Repository, error) {
 }
 
 func (repo *Repository) gitCommand(callerArgs ...string) *exec.Cmd {
-	// Disable replace references when running our commands:
-	args := []string{"--no-replace-objects"}
+	args := []string{
+		// Disable replace references when running our commands:
+		"--no-replace-objects",
+
+		// Disable the warning that grafts are deprecated, since we
+		// want to set the grafts file to `/dev/null` below (to
+		// disable grafts even where they are supported):
+		"-c", "advice.graftFileDeprecated=false",
+	}
 
 	args = append(args, callerArgs...)
 


### PR DESCRIPTION
Git has deprecated "info/grafts", and as part of this now emits a deprecation warning if the user appears to be using a grafts file.

We *don't* want to use a grafts file; in fact, we want to suppress it unconditionally even for repositories that would normally use grafts. We do that by setting `GIT_GRAFT_FILE=/dev/null`; i.e., by telling git to use an empty grafts file.

Unfortunately, the way that we *suppress* grafts triggers git's warning!

So...continue suppressing grafts as before, but *also* add a new git option `-c advice.graftFileDeprecated=false`, to suppress the deprecation warning.

This should be perfectly backwards compatible. Versions of git prior to the deprecation will suppress any grafts and will ignore the new git option. The current (as of this writing) version of git will also suppress any grafts and will elide the warning due to the use of the new git option.

It's not 100% certain that this will be perfectly forwards compatible (is anything ever?). It's possible that the git project, after it removes the grafts facility, might start treating a request to use grafts as a hard error, in which case our grafts suppression will cause git to fail. If that happens, we will have to be cleverer. For example, we might check which version of Git is in use, and only suppress grafts for versions that still allow them. But we'll cross that bridge if/when we come to it.

Fixes #44.

/cc @onlyjob, @jokeyrhyme, @peff
