### PR TITLE
Generate better JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ at the command line to view the contents of the object. (Use `--names=none` if y
 
 By default, only statistics above a minimal level of concern are reported. Use `--verbose` (as above) to request that all statistics be output. Use `--threshold=<value>` to suppress the reporting of statistics below a specified level of concern. (`<value>` is interpreted as a numerical value corresponding to the number of asterisks.) Use `--critical` to report only statistics with a critical level of concern (equivalent to `--threshold=30`).
 
-If you'd like the output in machine-readable format, including exact numbers, use the `--json` option.
+If you'd like the output in machine-readable format, including exact numbers, use the `--json` option. You can use `--json-version=1` or `--json-version=2` to choose between old and new style JSON output.
 
 To get a list of other options, run
 

--- a/counts/counts.go
+++ b/counts/counts.go
@@ -14,8 +14,8 @@ func NewCount32(n uint64) Count32 {
 	return Count32(n)
 }
 
-func (n Count32) ToUint64() uint64 {
-	return uint64(n)
+func (n Count32) ToUint64() (uint64, bool) {
+	return uint64(n), n == math.MaxUint32
 }
 
 // Return the sum of two Count32s, capped at math.MaxUint32.
@@ -62,8 +62,8 @@ func NewCount64(n uint64) Count64 {
 	return Count64(n)
 }
 
-func (n Count64) ToUint64() uint64 {
-	return uint64(n)
+func (n Count64) ToUint64() (uint64, bool) {
+	return uint64(n), n == math.MaxUint64
 }
 
 // Return the sum of two Count64s, capped at math.MaxUint64.

--- a/counts/counts_test.go
+++ b/counts/counts_test.go
@@ -11,25 +11,43 @@ import (
 func TestCount32(t *testing.T) {
 	assert := assert.New(t)
 
+	var value uint64
+	var overflow bool
+
 	c := counts.NewCount32(0)
-	assert.Equalf(uint64(0), c.ToUint64(), "NewCount32(0).ToUint64() should be 0")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0), value, "NewCount32(0).ToUint64() should be 0")
+	assert.False(overflow, "NewCount32(0).ToUint64() does not overflow")
 
 	c.Increment(counts.Count32(0xf0000000))
-	assert.Equalf(uint64(0xf0000000), c.ToUint64(), "Count32(0xf0000000).ToUint64() value")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0xf0000000), value, "Count32(0xf0000000).ToUint64() value")
+	assert.False(overflow, "NewCount32(0xf0000000).ToUint64() does not overflow")
 
 	c.Increment(counts.Count32(0xf0000000))
-	assert.Equalf(uint64(0xffffffff), c.ToUint64(), "Count32(0xffffffff).ToUint64() value")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0xffffffff), value, "Count32(0xffffffff).ToUint64() value")
+	assert.True(overflow, "NewCount32(0xffffffff).ToUint64() overflows")
 }
 
 func TestCount64(t *testing.T) {
 	assert := assert.New(t)
 
+	var value uint64
+	var overflow bool
+
 	c := counts.NewCount64(0)
-	assert.Equalf(uint64(0), c.ToUint64(), "NewCount64(0).ToUint64() should be 0")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0), value, "NewCount64(0).ToUint64() should be 0")
+	assert.False(overflow, "NewCount64(0).ToUint64() does not overflow")
 
 	c.Increment(counts.Count64(0xf000000000000000))
-	assert.Equalf(uint64(0xf000000000000000), c.ToUint64(), "Count64(0xf000000000000000).ToUint64() value")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0xf000000000000000), value, "Count64(0xf000000000000000).ToUint64() value")
+	assert.False(overflow, "NewCount64(0xf000000000000000).ToUint64() does not overflow")
 
 	c.Increment(counts.Count64(0xf000000000000000))
-	assert.Equalf(uint64(0xffffffffffffffff), c.ToUint64(), "Count64(0xffffffffffffffff).ToUint64() value")
+	value, overflow = c.ToUint64()
+	assert.Equalf(uint64(0xffffffffffffffff), value, "Count64(0xffffffffffffffff).ToUint64() value")
+	assert.True(overflow, "NewCount64(0xffffffffffffffff).ToUint64() overflows")
 }

--- a/counts/human.go
+++ b/counts/human.go
@@ -15,30 +15,22 @@ type Humaner interface {
 	ToUint64() uint64
 }
 
-var MetricPrefixes []Prefix
-
-func init() {
-	MetricPrefixes = []Prefix{
-		{"", 1},
-		{"k", 1e3},
-		{"M", 1e6},
-		{"G", 1e9},
-		{"T", 1e12},
-		{"P", 1e15},
-	}
+var MetricPrefixes []Prefix = []Prefix{
+	{"", 1},
+	{"k", 1e3},
+	{"M", 1e6},
+	{"G", 1e9},
+	{"T", 1e12},
+	{"P", 1e15},
 }
 
-var BinaryPrefixes []Prefix
-
-func init() {
-	BinaryPrefixes = []Prefix{
-		{"", 1 << (10 * 0)},
-		{"Ki", 1 << (10 * 1)},
-		{"Mi", 1 << (10 * 2)},
-		{"Gi", 1 << (10 * 3)},
-		{"Ti", 1 << (10 * 4)},
-		{"Pi", 1 << (10 * 5)},
-	}
+var BinaryPrefixes []Prefix = []Prefix{
+	{"", 1 << (10 * 0)},
+	{"Ki", 1 << (10 * 1)},
+	{"Mi", 1 << (10 * 2)},
+	{"Gi", 1 << (10 * 3)},
+	{"Ti", 1 << (10 * 4)},
+	{"Pi", 1 << (10 * 5)},
 }
 
 // Format values, aligned, in `len(unit) + 10` or fewer characters

--- a/counts/human.go
+++ b/counts/human.go
@@ -5,41 +5,53 @@ import (
 	"math"
 )
 
+// A quantity that can be made human-readable using Human().
+type Humanable interface {
+	Human(Humaner, string) (string, string)
+	ToUint64() uint64
+}
+
+// An object that can format a Humanable in human-readable format.
+type Humaner struct {
+	name     string
+	prefixes []Prefix
+}
+
 type Prefix struct {
 	Name       string
 	Multiplier uint64
 }
 
-// A quantity that can be made human-readable using Human().
-type Humanable interface {
-	Human([]Prefix, string) (string, string)
-	ToUint64() uint64
+var Metric = Humaner{
+	name: "metric",
+	prefixes: []Prefix{
+		{"", 1},
+		{"k", 1e3},
+		{"M", 1e6},
+		{"G", 1e9},
+		{"T", 1e12},
+		{"P", 1e15},
+	},
 }
 
-var MetricPrefixes []Prefix = []Prefix{
-	{"", 1},
-	{"k", 1e3},
-	{"M", 1e6},
-	{"G", 1e9},
-	{"T", 1e12},
-	{"P", 1e15},
-}
-
-var BinaryPrefixes []Prefix = []Prefix{
-	{"", 1 << (10 * 0)},
-	{"Ki", 1 << (10 * 1)},
-	{"Mi", 1 << (10 * 2)},
-	{"Gi", 1 << (10 * 3)},
-	{"Ti", 1 << (10 * 4)},
-	{"Pi", 1 << (10 * 5)},
+var Binary = Humaner{
+	name: "binary",
+	prefixes: []Prefix{
+		{"", 1 << (10 * 0)},
+		{"Ki", 1 << (10 * 1)},
+		{"Mi", 1 << (10 * 2)},
+		{"Gi", 1 << (10 * 3)},
+		{"Ti", 1 << (10 * 4)},
+		{"Pi", 1 << (10 * 5)},
+	},
 }
 
 // Format values, aligned, in `len(unit) + 10` or fewer characters
 // (except for extremely large numbers).
-func Human(n uint64, prefixes []Prefix, unit string) (string, string) {
-	prefix := prefixes[0]
+func (h *Humaner) Format(n uint64, unit string) (string, string) {
+	prefix := h.prefixes[0]
 	wholePart := n
-	for _, p := range prefixes {
+	for _, p := range h.prefixes {
 		w := n / p.Multiplier
 		if w >= 1 {
 			wholePart = w
@@ -65,18 +77,18 @@ func Human(n uint64, prefixes []Prefix, unit string) (string, string) {
 	}
 }
 
-func (n Count32) Human(prefixes []Prefix, unit string) (string, string) {
+func (n Count32) Human(humaner Humaner, unit string) (string, string) {
 	if n == math.MaxUint32 {
 		return "∞", unit
 	} else {
-		return Human(uint64(n), prefixes, unit)
+		return humaner.Format(uint64(n), unit)
 	}
 }
 
-func (n Count64) Human(prefixes []Prefix, unit string) (string, string) {
+func (n Count64) Human(humaner Humaner, unit string) (string, string) {
 	if n == math.MaxUint64 {
 		return "∞", unit
 	} else {
-		return Human(uint64(n), prefixes, unit)
+		return humaner.Format(uint64(n), unit)
 	}
 }

--- a/counts/human.go
+++ b/counts/human.go
@@ -10,7 +10,8 @@ type Prefix struct {
 	Multiplier uint64
 }
 
-type Humaner interface {
+// A quantity that can be made human-readable using Human().
+type Humanable interface {
 	Human([]Prefix, string) (string, string)
 	ToUint64() uint64
 }

--- a/counts/human.go
+++ b/counts/human.go
@@ -2,14 +2,10 @@ package counts
 
 import (
 	"fmt"
-	"math"
 )
 
 // A quantity that can be made human-readable using Human().
 type Humanable interface {
-	// Return the value and units as separate strings.
-	Human(Humaner, string) (string, string)
-
 	// Return the value as a uint64, and a boolean telling whether it
 	// overflowed.
 	ToUint64() (uint64, bool)
@@ -50,10 +46,11 @@ var Binary = Humaner{
 	},
 }
 
-// Format values, aligned, in `len(unit) + 10` or fewer characters
-// (except for extremely large numbers).
-func (h *Humaner) Format(n uint64, unit string) (string, string) {
+// Format n, aligned, in `len(unit) + 10` or fewer characters (except
+// for extremely large numbers).
+func (h *Humaner) FormatNumber(n uint64, unit string) (string, string) {
 	prefix := h.prefixes[0]
+
 	wholePart := n
 	for _, p := range h.prefixes {
 		w := n / p.Multiplier
@@ -81,18 +78,13 @@ func (h *Humaner) Format(n uint64, unit string) (string, string) {
 	}
 }
 
-func (n Count32) Human(humaner Humaner, unit string) (string, string) {
-	if n == math.MaxUint32 {
+// Format values, aligned, in `len(unit) + 10` or fewer characters
+// (except for extremely large numbers).
+func (h *Humaner) Format(value Humanable, unit string) (string, string) {
+	n, overflow := value.ToUint64()
+	if overflow {
 		return "∞", unit
-	} else {
-		return humaner.Format(uint64(n), unit)
 	}
-}
 
-func (n Count64) Human(humaner Humaner, unit string) (string, string) {
-	if n == math.MaxUint64 {
-		return "∞", unit
-	} else {
-		return humaner.Format(uint64(n), unit)
-	}
+	return h.FormatNumber(n, unit)
 }

--- a/counts/human.go
+++ b/counts/human.go
@@ -7,8 +7,12 @@ import (
 
 // A quantity that can be made human-readable using Human().
 type Humanable interface {
+	// Return the value and units as separate strings.
 	Human(Humaner, string) (string, string)
-	ToUint64() uint64
+
+	// Return the value as a uint64, and a boolean telling whether it
+	// overflowed.
+	ToUint64() (uint64, bool)
 }
 
 // An object that can format a Humanable in human-readable format.

--- a/counts/human.go
+++ b/counts/human.go
@@ -46,6 +46,10 @@ var Binary = Humaner{
 	},
 }
 
+func (h *Humaner) Name() string {
+	return h.name
+}
+
 // Format n, aligned, in `len(unit) + 10` or fewer characters (except
 // for extremely large numbers).
 func (h *Humaner) FormatNumber(n uint64, unit string) (string, string) {

--- a/counts/human_test.go
+++ b/counts/human_test.go
@@ -114,8 +114,8 @@ func TestLimits32(t *testing.T) {
 
 	c := counts.NewCount32(0xffffffff)
 	number, unit := c.Human(counts.Metric, "cd")
-	assert.Equalf("∞", number, "Number for Count32(%d) in metric", c.ToUint64())
-	assert.Equalf("cd", unit, "Unit for Count32(%d) in metric", c.ToUint64())
+	assert.Equalf("∞", number, "Number for Count32(0xffffffff) in metric")
+	assert.Equalf("cd", unit, "Unit for Count32(0xffffffff) in metric")
 }
 
 func TestLimits64(t *testing.T) {
@@ -123,6 +123,6 @@ func TestLimits64(t *testing.T) {
 
 	c := counts.NewCount64(0xffffffffffffffff)
 	number, unit := c.Human(counts.Metric, "B")
-	assert.Equalf("∞", number, "Number for Count64(%d) in metric", c.ToUint64())
-	assert.Equalf("B", unit, "Unit for Count64(%d) in metric", c.ToUint64())
+	assert.Equalf("∞", number, "Number for Count64(0xffffffffffffffff) in metric")
+	assert.Equalf("B", unit, "Unit for Count64(0xffffffffffffffff) in metric")
 }

--- a/counts/human_test.go
+++ b/counts/human_test.go
@@ -52,18 +52,18 @@ func TestMetric(t *testing.T) {
 		{12345678900000000000, "12346", "Pcd"}, // Not ideal, but ok
 		{0xffffffffffffffff, "18447", "Pcd"},   // Not ideal, but ok
 	} {
-		number, unit := counts.Metric.Format(ht.n, "cd")
+		number, unit := counts.Metric.FormatNumber(ht.n, "cd")
 		assert.Equalf(ht.number, number, "Number for %d in metric", ht.n)
 		assert.Equalf(ht.unit, unit, "Unit for %d in metric", ht.n)
 		if ht.n < 0xffffffff {
 			c := counts.NewCount32(ht.n)
-			number, unit := c.Human(counts.Metric, "cd")
+			number, unit := counts.Metric.Format(c, "cd")
 			assert.Equalf(ht.number, number, "Number for Count32(%d) in metric", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count32(%d) in metric", ht.n)
 		}
 		if ht.n < 0xffffffffffffffff {
 			c := counts.NewCount64(ht.n)
-			number, unit := c.Human(counts.Metric, "cd")
+			number, unit := counts.Metric.Format(c, "cd")
 			assert.Equalf(ht.number, number, "Number for Count64(%d) in metric", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count64(%d) in metric", ht.n)
 		}
@@ -91,18 +91,18 @@ func TestBinary(t *testing.T) {
 		{1152921504606846976, "1024", "PiB"},
 		{0xffffffffffffffff, "16384", "PiB"},
 	} {
-		number, unit := counts.Binary.Format(ht.n, "B")
+		number, unit := counts.Binary.FormatNumber(ht.n, "B")
 		assert.Equalf(ht.number, number, "Number for %d in binary", ht.n)
 		assert.Equalf(ht.unit, unit, "Unit for %d in binary", ht.n)
 		if ht.n < 0xffffffff {
 			c := counts.NewCount32(ht.n)
-			number, unit := c.Human(counts.Binary, "B")
+			number, unit := counts.Binary.Format(c, "B")
 			assert.Equalf(ht.number, number, "Number for Count32(%d) in binary", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count32(%d) in binary", ht.n)
 		}
 		if ht.n < 0xffffffffffffffff {
 			c := counts.NewCount64(ht.n)
-			number, unit := c.Human(counts.Binary, "B")
+			number, unit := counts.Binary.Format(c, "B")
 			assert.Equalf(ht.number, number, "Number for Count64(%d) in binary", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count64(%d) in binary", ht.n)
 		}
@@ -113,7 +113,7 @@ func TestLimits32(t *testing.T) {
 	assert := assert.New(t)
 
 	c := counts.NewCount32(0xffffffff)
-	number, unit := c.Human(counts.Metric, "cd")
+	number, unit := counts.Metric.Format(c, "cd")
 	assert.Equalf("∞", number, "Number for Count32(0xffffffff) in metric")
 	assert.Equalf("cd", unit, "Unit for Count32(0xffffffff) in metric")
 }
@@ -122,7 +122,7 @@ func TestLimits64(t *testing.T) {
 	assert := assert.New(t)
 
 	c := counts.NewCount64(0xffffffffffffffff)
-	number, unit := c.Human(counts.Metric, "B")
+	number, unit := counts.Metric.Format(c, "B")
 	assert.Equalf("∞", number, "Number for Count64(0xffffffffffffffff) in metric")
 	assert.Equalf("B", unit, "Unit for Count64(0xffffffffffffffff) in metric")
 }

--- a/counts/human_test.go
+++ b/counts/human_test.go
@@ -52,18 +52,18 @@ func TestMetric(t *testing.T) {
 		{12345678900000000000, "12346", "Pcd"}, // Not ideal, but ok
 		{0xffffffffffffffff, "18447", "Pcd"},   // Not ideal, but ok
 	} {
-		number, unit := counts.Human(ht.n, counts.MetricPrefixes, "cd")
+		number, unit := counts.Metric.Format(ht.n, "cd")
 		assert.Equalf(ht.number, number, "Number for %d in metric", ht.n)
 		assert.Equalf(ht.unit, unit, "Unit for %d in metric", ht.n)
 		if ht.n < 0xffffffff {
 			c := counts.NewCount32(ht.n)
-			number, unit := c.Human(counts.MetricPrefixes, "cd")
+			number, unit := c.Human(counts.Metric, "cd")
 			assert.Equalf(ht.number, number, "Number for Count32(%d) in metric", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count32(%d) in metric", ht.n)
 		}
 		if ht.n < 0xffffffffffffffff {
 			c := counts.NewCount64(ht.n)
-			number, unit := c.Human(counts.MetricPrefixes, "cd")
+			number, unit := c.Human(counts.Metric, "cd")
 			assert.Equalf(ht.number, number, "Number for Count64(%d) in metric", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count64(%d) in metric", ht.n)
 		}
@@ -91,18 +91,18 @@ func TestBinary(t *testing.T) {
 		{1152921504606846976, "1024", "PiB"},
 		{0xffffffffffffffff, "16384", "PiB"},
 	} {
-		number, unit := counts.Human(ht.n, counts.BinaryPrefixes, "B")
+		number, unit := counts.Binary.Format(ht.n, "B")
 		assert.Equalf(ht.number, number, "Number for %d in binary", ht.n)
 		assert.Equalf(ht.unit, unit, "Unit for %d in binary", ht.n)
 		if ht.n < 0xffffffff {
 			c := counts.NewCount32(ht.n)
-			number, unit := c.Human(counts.BinaryPrefixes, "B")
+			number, unit := c.Human(counts.Binary, "B")
 			assert.Equalf(ht.number, number, "Number for Count32(%d) in binary", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count32(%d) in binary", ht.n)
 		}
 		if ht.n < 0xffffffffffffffff {
 			c := counts.NewCount64(ht.n)
-			number, unit := c.Human(counts.BinaryPrefixes, "B")
+			number, unit := c.Human(counts.Binary, "B")
 			assert.Equalf(ht.number, number, "Number for Count64(%d) in binary", ht.n)
 			assert.Equalf(ht.unit, unit, "Unit for Count64(%d) in binary", ht.n)
 		}
@@ -113,7 +113,7 @@ func TestLimits32(t *testing.T) {
 	assert := assert.New(t)
 
 	c := counts.NewCount32(0xffffffff)
-	number, unit := c.Human(counts.MetricPrefixes, "cd")
+	number, unit := c.Human(counts.Metric, "cd")
 	assert.Equalf("∞", number, "Number for Count32(%d) in metric", c.ToUint64())
 	assert.Equalf("cd", unit, "Unit for Count32(%d) in metric", c.ToUint64())
 }
@@ -122,7 +122,7 @@ func TestLimits64(t *testing.T) {
 	assert := assert.New(t)
 
 	c := counts.NewCount64(0xffffffffffffffff)
-	number, unit := c.Human(counts.MetricPrefixes, "B")
+	number, unit := c.Human(counts.Metric, "B")
 	assert.Equalf("∞", number, "Number for Count64(%d) in metric", c.ToUint64())
 	assert.Equalf("B", unit, "Unit for Count64(%d) in metric", c.ToUint64())
 }

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -166,7 +166,7 @@ func mainImplementation() error {
 	}
 
 	if jsonOutput {
-		j, err := sizes.JSONString(historySize.Contents(), threshold, nameStyle)
+		j, err := historySize.JSON(threshold, nameStyle)
 		if err != nil {
 			return fmt.Errorf("could not convert %v to json: %s", historySize, err)
 		}

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -167,11 +166,11 @@ func mainImplementation() error {
 	}
 
 	if jsonOutput {
-		s, err := json.MarshalIndent(historySize, "", "    ")
+		j, err := sizes.JSONString(historySize.Contents(), threshold, nameStyle)
 		if err != nil {
 			return fmt.Errorf("could not convert %v to json: %s", historySize, err)
 		}
-		fmt.Printf("%s\n", s)
+		fmt.Printf("%s\n", j)
 	} else {
 		io.WriteString(os.Stdout, sizes.TableString(historySize.Contents(), threshold, nameStyle))
 	}

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -65,29 +65,31 @@ func mainImplementation() error {
 	var progress bool
 	var version bool
 
-	pflag.BoolVar(&processBranches, "branches", false, "process all branches")
-	pflag.BoolVar(&processTags, "tags", false, "process all tags")
-	pflag.BoolVar(&processRemotes, "remotes", false, "process all remote-tracking branches")
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 
-	pflag.VarP(
+	flags.BoolVar(&processBranches, "branches", false, "process all branches")
+	flags.BoolVar(&processTags, "tags", false, "process all tags")
+	flags.BoolVar(&processRemotes, "remotes", false, "process all remote-tracking branches")
+
+	flags.VarP(
 		sizes.NewThresholdFlagValue(&threshold, 0),
 		"verbose", "v", "report all statistics, whether concerning or not",
 	)
-	pflag.Lookup("verbose").NoOptDefVal = "true"
+	flags.Lookup("verbose").NoOptDefVal = "true"
 
-	pflag.Var(
+	flags.Var(
 		&threshold, "threshold",
 		"minimum level of concern (i.e., number of stars) that should be\n"+
 			"                              reported",
 	)
 
-	pflag.Var(
+	flags.Var(
 		sizes.NewThresholdFlagValue(&threshold, 30),
 		"critical", "only report critical statistics",
 	)
-	pflag.Lookup("critical").NoOptDefVal = "true"
+	flags.Lookup("critical").NoOptDefVal = "true"
 
-	pflag.Var(
+	flags.Var(
 		&nameStyle, "names",
 		"display names of large objects in the specified `style`:\n"+
 			"        --names=none            omit footnotes entirely\n"+
@@ -95,24 +97,27 @@ func mainImplementation() error {
 			"        --names=full            show full names",
 	)
 
-	pflag.BoolVarP(&jsonOutput, "json", "j", false, "output results in JSON format")
-	pflag.UintVar(&jsonVersion, "json-version", 1, "JSON format version to output (1 or 2)")
+	flags.BoolVarP(&jsonOutput, "json", "j", false, "output results in JSON format")
+	flags.UintVar(&jsonVersion, "json-version", 1, "JSON format version to output (1 or 2)")
 
 	atty, err := isatty.Isatty(os.Stderr.Fd())
 	if err != nil {
 		atty = false
 	}
-	pflag.BoolVar(&progress, "progress", atty, "report progress to stderr")
-	pflag.BoolVar(&version, "version", false, "report the git-sizer version number")
-	pflag.Var(&NegatedBoolValue{&progress}, "no-progress", "suppress progress output")
-	pflag.Lookup("no-progress").NoOptDefVal = "true"
+	flags.BoolVar(&progress, "progress", atty, "report progress to stderr")
+	flags.BoolVar(&version, "version", false, "report the git-sizer version number")
+	flags.Var(&NegatedBoolValue{&progress}, "no-progress", "suppress progress output")
+	flags.Lookup("no-progress").NoOptDefVal = "true"
 
-	pflag.StringVar(&cpuprofile, "cpuprofile", "", "write cpu profile to file")
-	pflag.CommandLine.MarkHidden("cpuprofile")
+	flags.StringVar(&cpuprofile, "cpuprofile", "", "write cpu profile to file")
+	flags.MarkHidden("cpuprofile")
 
-	pflag.CommandLine.SortFlags = false
+	flags.SortFlags = false
 
-	pflag.Parse()
+	err = flags.Parse(os.Args[1:])
+	if err != nil {
+		return err
+	}
 
 	if jsonOutput && !(jsonVersion == 1 || jsonVersion == 2) {
 		return fmt.Errorf("JSON version must be 1 or 2")
@@ -136,7 +141,7 @@ func mainImplementation() error {
 		return nil
 	}
 
-	args := pflag.Args()
+	args := flags.Args()
 
 	if len(args) != 0 {
 		return errors.New("excess arguments")

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -173,7 +173,7 @@ func mainImplementation() error {
 		}
 		fmt.Printf("%s\n", s)
 	} else {
-		io.WriteString(os.Stdout, historySize.TableString(threshold, nameStyle))
+		io.WriteString(os.Stdout, sizes.TableString(historySize.Contents(), threshold, nameStyle))
 	}
 
 	return nil

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -172,7 +172,7 @@ func mainImplementation() error {
 		}
 		fmt.Printf("%s\n", j)
 	} else {
-		io.WriteString(os.Stdout, sizes.TableString(historySize.Contents(), threshold, nameStyle))
+		io.WriteString(os.Stdout, historySize.TableString(threshold, nameStyle))
 	}
 
 	return nil

--- a/git/git.go
+++ b/git/git.go
@@ -310,16 +310,10 @@ func PrefixFilter(prefix string) ReferenceFilter {
 }
 
 var (
-	BranchesFilter ReferenceFilter
-	TagsFilter     ReferenceFilter
-	RemotesFilter  ReferenceFilter
+	BranchesFilter ReferenceFilter = PrefixFilter("refs/heads/")
+	TagsFilter     ReferenceFilter = PrefixFilter("refs/tags/")
+	RemotesFilter  ReferenceFilter = PrefixFilter("refs/remotes/")
 )
-
-func init() {
-	BranchesFilter = PrefixFilter("refs/heads/")
-	TagsFilter = PrefixFilter("refs/tags/")
-	RemotesFilter = PrefixFilter("refs/remotes/")
-}
 
 func notNilFilters(filters ...ReferenceFilter) []ReferenceFilter {
 	var ret []ReferenceFilter

--- a/sizes/footnotes.go
+++ b/sizes/footnotes.go
@@ -1,0 +1,46 @@
+package sizes
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Footnotes struct {
+	footnotes []string
+	indexes   map[string]int
+}
+
+func NewFootnotes() *Footnotes {
+	return &Footnotes{
+		indexes: make(map[string]int),
+	}
+}
+
+func (f *Footnotes) CreateCitation(footnote string) string {
+	if footnote == "" {
+		return ""
+	}
+
+	index, ok := f.indexes[footnote]
+	if !ok {
+		index = len(f.indexes) + 1
+		f.footnotes = append(f.footnotes, footnote)
+		f.indexes[footnote] = index
+	}
+	return fmt.Sprintf("[%d]", index)
+}
+
+func (f *Footnotes) String() string {
+	if len(f.footnotes) == 0 {
+		return ""
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteByte('\n')
+	for i, footnote := range f.footnotes {
+		index := i + 1
+		citation := fmt.Sprintf("[%d]", index)
+		fmt.Fprintf(buf, "%-4s %s\n", citation, footnote)
+	}
+	return buf.String()
+}

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -159,7 +159,8 @@ func (l *item) Footnote(nameStyle NameStyle) string {
 // return the string that should be used as its "level of concern" and
 // `true`; otherwise, return `"", false`.
 func (l *item) levelOfConcern(threshold Threshold) (string, bool) {
-	alert := Threshold(float64(l.value.ToUint64()) / l.scale)
+	value, _ := l.value.ToUint64()
+	alert := Threshold(float64(value) / l.scale)
 	if alert < threshold {
 		return "", false
 	}

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -154,7 +154,7 @@ func newItem(
 }
 
 func (l *item) Emit(t *table, buf io.Writer, indent int) {
-	levelOfConcern, interesting := l.levelOfConcern(t)
+	levelOfConcern, interesting := l.levelOfConcern(t.threshold)
 	if !interesting {
 		return
 	}
@@ -187,9 +187,9 @@ func (l *item) Footnote(nameStyle NameStyle) string {
 // If this item's alert level is at least as high as the threshold,
 // return the string that should be used as its "level of concern" and
 // `true`; otherwise, return `"", false`.
-func (l *item) levelOfConcern(t *table) (string, bool) {
+func (l *item) levelOfConcern(threshold Threshold) (string, bool) {
 	alert := Threshold(float64(l.value.ToUint64()) / l.scale)
-	if alert < t.threshold {
+	if alert < threshold {
 		return "", false
 	}
 	if alert > 30 {

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -346,7 +346,7 @@ type table struct {
 }
 
 func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) string {
-	contents := s.Contents()
+	contents := s.contents()
 	t := table{
 		threshold: threshold,
 		nameStyle: nameStyle,
@@ -423,14 +423,14 @@ func (t *table) formatRow(
 }
 
 func (s HistorySize) JSON(threshold Threshold, nameStyle NameStyle) ([]byte, error) {
-	contents := s.Contents()
+	contents := s.contents()
 	items := make(map[string]*item)
 	contents.CollectItems(items)
 	j, err := json.MarshalIndent(items, "", "    ")
 	return j, err
 }
 
-func (s HistorySize) Contents() tableContents {
+func (s HistorySize) contents() tableContents {
 	S := newSection
 	I := newItem
 	metric := counts.Metric

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -193,14 +193,14 @@ func (i *item) MarshalJSON() ([]byte, error) {
 	value, _ := i.value.ToUint64()
 
 	stat := struct {
-		Description       string
-		Value             uint64
-		Unit              string
-		Prefixes          string
-		ReferenceValue    float64
-		LevelOfConcern    float64
-		ObjectName        string `json:",omitempty"`
-		ObjectDescription string `json:",omitempty"`
+		Description       string  `json:"description"`
+		Value             uint64  `json:"value"`
+		Unit              string  `json:"unit"`
+		Prefixes          string  `json:"prefixes"`
+		ReferenceValue    float64 `json:"referenceValue"`
+		LevelOfConcern    float64 `json:"levelOfConcern"`
+		ObjectName        string  `json:"objectName,omitempty"`
+		ObjectDescription string  `json:"objectDescription,omitempty"`
 	}{
 		Description:    i.description,
 		Value:          value,

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -102,7 +102,7 @@ func (s *section) Emit(t *table) {
 type item struct {
 	name     string
 	path     *Path
-	value    counts.Humaner
+	value    counts.Humanable
 	prefixes []counts.Prefix
 	unit     string
 	scale    float64
@@ -111,7 +111,7 @@ type item struct {
 func newItem(
 	name string,
 	path *Path,
-	value counts.Humaner,
+	value counts.Humanable,
 	prefixes []counts.Prefix,
 	unit string,
 	scale float64,

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -119,7 +119,7 @@ func (s *section) Emit(t *table, buf io.Writer, indent int) {
 		// own header, but prints the table header:
 		fmt.Fprint(buf, t.generateHeader())
 	} else {
-		t.formatRow(buf, indent, s.name, "", "", "", "")
+		t.formatSectionHeader(buf, indent, s.name)
 	}
 
 	fmt.Fprint(buf, linesBuf.String())
@@ -423,6 +423,10 @@ func (t *table) generateLines() string {
 
 func (t *table) emitBlankRow(buf io.Writer) {
 	t.formatRow(buf, 0, "", "", "", "", "")
+}
+
+func (t *table) formatSectionHeader(buf io.Writer, indent int, name string) {
+	t.formatRow(buf, indent, name, "", "", "", "")
 }
 
 func (t *table) formatRow(

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -100,29 +100,29 @@ func (s *section) Emit(t *table) {
 
 // A line containing data in the tabular output.
 type item struct {
-	name     string
-	path     *Path
-	value    counts.Humanable
-	prefixes []counts.Prefix
-	unit     string
-	scale    float64
+	name    string
+	path    *Path
+	value   counts.Humanable
+	humaner counts.Humaner
+	unit    string
+	scale   float64
 }
 
 func newItem(
 	name string,
 	path *Path,
 	value counts.Humanable,
-	prefixes []counts.Prefix,
+	humaner counts.Humaner,
 	unit string,
 	scale float64,
 ) *item {
 	return &item{
-		name:     name,
-		path:     path,
-		value:    value,
-		prefixes: prefixes,
-		unit:     unit,
-		scale:    scale,
+		name:    name,
+		path:    path,
+		value:   value,
+		humaner: humaner,
+		unit:    unit,
+		scale:   scale,
 	}
 }
 
@@ -131,7 +131,7 @@ func (l *item) Emit(t *table) {
 	if !interesting {
 		return
 	}
-	valueString, unitString := l.value.Human(l.prefixes, l.unit)
+	valueString, unitString := l.value.Human(l.humaner, l.unit)
 	t.formatRow(
 		l.name, t.footnotes.CreateCitation(l.Footnote(t.nameStyle)),
 		valueString, unitString,
@@ -375,8 +375,8 @@ func (t *table) formatRow(
 func (s HistorySize) Contents() tableContents {
 	S := newSection
 	I := newItem
-	metric := counts.MetricPrefixes
-	binary := counts.BinaryPrefixes
+	metric := counts.Metric
+	binary := counts.Binary
 	return S(
 		"",
 		S(

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -421,11 +421,12 @@ func (t *table) formatRow(
 	)
 }
 
-func JSONString(contents tableContents, threshold Threshold, nameStyle NameStyle) (string, error) {
+func (s HistorySize) JSON(threshold Threshold, nameStyle NameStyle) ([]byte, error) {
+	contents := s.Contents()
 	items := make(map[string]*item)
 	contents.CollectItems(items)
 	j, err := json.MarshalIndent(items, "", "    ")
-	return string(j), err
+	return j, err
 }
 
 func (s HistorySize) Contents() tableContents {

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -160,9 +160,8 @@ func (l *item) Emit(t *table, buf io.Writer, indent int) {
 	}
 	valueString, unitString := l.value.Human(l.prefixes, l.unit)
 	t.formatRow(
-		buf,
-		indent,
-		l.name, l.Footnote(t.nameStyle),
+		buf, indent,
+		l.name, t.footnotes.CreateCitation(l.Footnote(t.nameStyle)),
 		valueString, unitString,
 		levelOfConcern,
 	)
@@ -428,13 +427,12 @@ func (t *table) emitBlankRow(buf io.Writer) {
 
 func (t *table) formatRow(
 	buf io.Writer, indent int,
-	name, footnote, valueString, unitString, levelOfConcern string,
+	name, citation, valueString, unitString, levelOfConcern string,
 ) {
 	prefix := ""
 	if indent != 0 {
 		prefix = spaces[:2*(indent-1)] + "* "
 	}
-	citation := t.footnotes.CreateCitation(footnote)
 	spacer := ""
 	l := len(prefix) + len(name) + len(citation)
 	if l < 28 {

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -114,11 +114,7 @@ func (s *section) Emit(t *table, buf io.Writer, indent int) {
 	}
 
 	// There's output, so emit the section header first:
-	if indent == -1 {
-		// As a special case, the top-level section doesn't have its
-		// own header, but prints the table header:
-		fmt.Fprint(buf, t.generateHeader())
-	} else {
+	if s.name != "" {
 		t.formatSectionHeader(buf, indent, s.name)
 	}
 
@@ -332,8 +328,12 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 
 	buf := &bytes.Buffer{}
 	t.contents.Emit(&t, buf, -1)
-	linesString := buf.String()
-	return linesString + t.footnotes.String()
+
+	if buf.Len() == 0 {
+		return ""
+	}
+
+	return t.generateHeader() + buf.String() + t.footnotes.String()
 }
 
 func (t *table) generateHeader() string {

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -330,11 +330,9 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 		footnotes: NewFootnotes(),
 	}
 
-	return t.String()
-}
-
-func (t *table) String() string {
-	linesString := t.generateLines()
+	buf := &bytes.Buffer{}
+	t.contents.Emit(&t, buf, -1)
+	linesString := buf.String()
 	return linesString + t.footnotes.String()
 }
 
@@ -342,12 +340,6 @@ func (t *table) generateHeader() string {
 	buf := &bytes.Buffer{}
 	fmt.Fprintln(buf, "| Name                         | Value     | Level of concern               |")
 	fmt.Fprintln(buf, "| ---------------------------- | --------- | ------------------------------ |")
-	return buf.String()
-}
-
-func (t *table) generateLines() string {
-	buf := &bytes.Buffer{}
-	t.contents.Emit(t, buf, -1)
 	return buf.String()
 }
 

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -131,7 +131,7 @@ func (l *item) Emit(t *table) {
 	if !interesting {
 		return
 	}
-	valueString, unitString := l.value.Human(l.humaner, l.unit)
+	valueString, unitString := l.humaner.Format(l.value, l.unit)
 	t.formatRow(
 		l.name, t.footnotes.CreateCitation(l.Footnote(t.nameStyle)),
 		valueString, unitString,

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -107,9 +107,6 @@ func (s *section) Emit(t *table, buf io.Writer, indent int) {
 	}
 
 	if linesBuf.Len() == 0 {
-		if indent == -1 {
-			fmt.Fprintln(buf, "No problems above the current threshold were found")
-		}
 		return
 	}
 
@@ -330,7 +327,7 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 	t.contents.Emit(&t, buf, -1)
 
 	if buf.Len() == 0 {
-		return ""
+		return "No problems above the current threshold were found\n"
 	}
 
 	return t.generateHeader() + buf.String() + t.footnotes.String()

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -323,78 +323,8 @@ type table struct {
 }
 
 func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) string {
-	S := newSection
-	I := newItem
-	metric := counts.MetricPrefixes
-	binary := counts.BinaryPrefixes
-	t := &table{
-		contents: S(
-			"",
-			S(
-				"Overall repository size",
-				S(
-					"Commits",
-					I("Count", nil, s.UniqueCommitCount, metric, " ", 500e3),
-					I("Total size", nil, s.UniqueCommitSize, binary, "B", 250e6),
-				),
-
-				S(
-					"Trees",
-					I("Count", nil, s.UniqueTreeCount, metric, " ", 1.5e6),
-					I("Total size", nil, s.UniqueTreeSize, binary, "B", 2e9),
-					I("Total tree entries", nil, s.UniqueTreeEntries, metric, " ", 50e6),
-				),
-
-				S(
-					"Blobs",
-					I("Count", nil, s.UniqueBlobCount, metric, " ", 1.5e6),
-					I("Total size", nil, s.UniqueBlobSize, binary, "B", 10e9),
-				),
-
-				S(
-					"Annotated tags",
-					I("Count", nil, s.UniqueTagCount, metric, " ", 25e3),
-				),
-
-				S(
-					"References",
-					I("Count", nil, s.ReferenceCount, metric, " ", 25e3),
-				),
-			),
-
-			S("Biggest objects",
-				S("Commits",
-					I("Maximum size", s.MaxCommitSizeCommit, s.MaxCommitSize, binary, "B", 50e3),
-					I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, metric, " ", 10),
-				),
-
-				S("Trees",
-					I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, metric, " ", 1000),
-				),
-
-				S("Blobs",
-					I("Maximum size", s.MaxBlobSizeBlob, s.MaxBlobSize, binary, "B", 10e6),
-				),
-			),
-
-			S("History structure",
-				I("Maximum history depth", nil, s.MaxHistoryDepth, metric, " ", 500e3),
-				I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, metric, " ", 1.001),
-			),
-
-			S("Biggest checkouts",
-				I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, metric, " ", 2000),
-				I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, metric, " ", 10),
-				I("Maximum path length", s.MaxPathLengthTree, s.MaxPathLength, binary, "B", 100),
-
-				I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, metric, " ", 50e3),
-				I("Total size of files", s.MaxExpandedBlobSizeTree, s.MaxExpandedBlobSize, binary, "B", 1e9),
-
-				I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, metric, " ", 25e3),
-
-				I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, metric, " ", 100),
-			),
-		),
+	t := table{
+		contents:  s.Contents(),
 		threshold: threshold,
 		nameStyle: nameStyle,
 		footnotes: NewFootnotes(),
@@ -445,5 +375,79 @@ func (t *table) formatRow(
 	fmt.Fprintf(
 		buf, "| %s%s%s%s | %5s %-3s | %-30s |\n",
 		prefix, name, spacer, citation, valueString, unitString, levelOfConcern,
+	)
+}
+
+func (s HistorySize) Contents() tableContents {
+	S := newSection
+	I := newItem
+	metric := counts.MetricPrefixes
+	binary := counts.BinaryPrefixes
+	return S(
+		"",
+		S(
+			"Overall repository size",
+			S(
+				"Commits",
+				I("Count", nil, s.UniqueCommitCount, metric, " ", 500e3),
+				I("Total size", nil, s.UniqueCommitSize, binary, "B", 250e6),
+			),
+
+			S(
+				"Trees",
+				I("Count", nil, s.UniqueTreeCount, metric, " ", 1.5e6),
+				I("Total size", nil, s.UniqueTreeSize, binary, "B", 2e9),
+				I("Total tree entries", nil, s.UniqueTreeEntries, metric, " ", 50e6),
+			),
+
+			S(
+				"Blobs",
+				I("Count", nil, s.UniqueBlobCount, metric, " ", 1.5e6),
+				I("Total size", nil, s.UniqueBlobSize, binary, "B", 10e9),
+			),
+
+			S(
+				"Annotated tags",
+				I("Count", nil, s.UniqueTagCount, metric, " ", 25e3),
+			),
+
+			S(
+				"References",
+				I("Count", nil, s.ReferenceCount, metric, " ", 25e3),
+			),
+		),
+
+		S("Biggest objects",
+			S("Commits",
+				I("Maximum size", s.MaxCommitSizeCommit, s.MaxCommitSize, binary, "B", 50e3),
+				I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, metric, " ", 10),
+			),
+
+			S("Trees",
+				I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, metric, " ", 1000),
+			),
+
+			S("Blobs",
+				I("Maximum size", s.MaxBlobSizeBlob, s.MaxBlobSize, binary, "B", 10e6),
+			),
+		),
+
+		S("History structure",
+			I("Maximum history depth", nil, s.MaxHistoryDepth, metric, " ", 500e3),
+			I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, metric, " ", 1.001),
+		),
+
+		S("Biggest checkouts",
+			I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, metric, " ", 2000),
+			I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, metric, " ", 10),
+			I("Maximum path length", s.MaxPathLengthTree, s.MaxPathLength, binary, "B", 100),
+
+			I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, metric, " ", 50e3),
+			I("Total size of files", s.MaxExpandedBlobSizeTree, s.MaxExpandedBlobSize, binary, "B", 1e9),
+
+			I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, metric, " ", 25e3),
+
+			I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, metric, " ", 100),
+		),
 	)
 }

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -309,22 +309,20 @@ func (n *NameStyle) Type() string {
 }
 
 type table struct {
-	contents  tableContents
 	threshold Threshold
 	nameStyle NameStyle
 	footnotes *Footnotes
 }
 
-func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) string {
+func TableString(contents tableContents, threshold Threshold, nameStyle NameStyle) string {
 	t := table{
-		contents:  s.Contents(),
 		threshold: threshold,
 		nameStyle: nameStyle,
 		footnotes: NewFootnotes(),
 	}
 
 	buf := &bytes.Buffer{}
-	t.contents.Emit(&t, buf, -1)
+	contents.Emit(&t, buf, -1)
 
 	if buf.Len() == 0 {
 		return "No problems above the current threshold were found\n"

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -345,7 +345,8 @@ type table struct {
 	buf           bytes.Buffer
 }
 
-func TableString(contents tableContents, threshold Threshold, nameStyle NameStyle) string {
+func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) string {
+	contents := s.Contents()
 	t := table{
 		threshold: threshold,
 		nameStyle: nameStyle,

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -384,42 +384,42 @@ func (s HistorySize) Contents() tableContents {
 			"Overall repository size",
 			S(
 				"Commits",
-				I("Count", nil, s.UniqueCommitCount, metric, " ", 500e3),
+				I("Count", nil, s.UniqueCommitCount, metric, "", 500e3),
 				I("Total size", nil, s.UniqueCommitSize, binary, "B", 250e6),
 			),
 
 			S(
 				"Trees",
-				I("Count", nil, s.UniqueTreeCount, metric, " ", 1.5e6),
+				I("Count", nil, s.UniqueTreeCount, metric, "", 1.5e6),
 				I("Total size", nil, s.UniqueTreeSize, binary, "B", 2e9),
-				I("Total tree entries", nil, s.UniqueTreeEntries, metric, " ", 50e6),
+				I("Total tree entries", nil, s.UniqueTreeEntries, metric, "", 50e6),
 			),
 
 			S(
 				"Blobs",
-				I("Count", nil, s.UniqueBlobCount, metric, " ", 1.5e6),
+				I("Count", nil, s.UniqueBlobCount, metric, "", 1.5e6),
 				I("Total size", nil, s.UniqueBlobSize, binary, "B", 10e9),
 			),
 
 			S(
 				"Annotated tags",
-				I("Count", nil, s.UniqueTagCount, metric, " ", 25e3),
+				I("Count", nil, s.UniqueTagCount, metric, "", 25e3),
 			),
 
 			S(
 				"References",
-				I("Count", nil, s.ReferenceCount, metric, " ", 25e3),
+				I("Count", nil, s.ReferenceCount, metric, "", 25e3),
 			),
 		),
 
 		S("Biggest objects",
 			S("Commits",
 				I("Maximum size", s.MaxCommitSizeCommit, s.MaxCommitSize, binary, "B", 50e3),
-				I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, metric, " ", 10),
+				I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, metric, "", 10),
 			),
 
 			S("Trees",
-				I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, metric, " ", 1000),
+				I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, metric, "", 1000),
 			),
 
 			S("Blobs",
@@ -428,21 +428,21 @@ func (s HistorySize) Contents() tableContents {
 		),
 
 		S("History structure",
-			I("Maximum history depth", nil, s.MaxHistoryDepth, metric, " ", 500e3),
-			I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, metric, " ", 1.001),
+			I("Maximum history depth", nil, s.MaxHistoryDepth, metric, "", 500e3),
+			I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, metric, "", 1.001),
 		),
 
 		S("Biggest checkouts",
-			I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, metric, " ", 2000),
-			I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, metric, " ", 10),
+			I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, metric, "", 2000),
+			I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, metric, "", 10),
 			I("Maximum path length", s.MaxPathLengthTree, s.MaxPathLength, binary, "B", 100),
 
-			I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, metric, " ", 50e3),
+			I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, metric, "", 50e3),
 			I("Total size of files", s.MaxExpandedBlobSizeTree, s.MaxExpandedBlobSize, binary, "B", 1e9),
 
-			I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, metric, " ", 25e3),
+			I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, metric, "", 25e3),
 
-			I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, metric, " ", 100),
+			I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, metric, "", 100),
 		),
 	)
 }

--- a/sizes/output.go
+++ b/sizes/output.go
@@ -327,6 +327,8 @@ type table struct {
 func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) string {
 	S := newSection
 	I := newItem
+	metric := counts.MetricPrefixes
+	binary := counts.BinaryPrefixes
 	t := &table{
 		contents: S(
 			"",
@@ -334,65 +336,65 @@ func (s HistorySize) TableString(threshold Threshold, nameStyle NameStyle) strin
 				"Overall repository size",
 				S(
 					"Commits",
-					I("Count", nil, s.UniqueCommitCount, counts.MetricPrefixes, " ", 500e3),
-					I("Total size", nil, s.UniqueCommitSize, counts.BinaryPrefixes, "B", 250e6),
+					I("Count", nil, s.UniqueCommitCount, metric, " ", 500e3),
+					I("Total size", nil, s.UniqueCommitSize, binary, "B", 250e6),
 				),
 
 				S(
 					"Trees",
-					I("Count", nil, s.UniqueTreeCount, counts.MetricPrefixes, " ", 1.5e6),
-					I("Total size", nil, s.UniqueTreeSize, counts.BinaryPrefixes, "B", 2e9),
-					I("Total tree entries", nil, s.UniqueTreeEntries, counts.MetricPrefixes, " ", 50e6),
+					I("Count", nil, s.UniqueTreeCount, metric, " ", 1.5e6),
+					I("Total size", nil, s.UniqueTreeSize, binary, "B", 2e9),
+					I("Total tree entries", nil, s.UniqueTreeEntries, metric, " ", 50e6),
 				),
 
 				S(
 					"Blobs",
-					I("Count", nil, s.UniqueBlobCount, counts.MetricPrefixes, " ", 1.5e6),
-					I("Total size", nil, s.UniqueBlobSize, counts.BinaryPrefixes, "B", 10e9),
+					I("Count", nil, s.UniqueBlobCount, metric, " ", 1.5e6),
+					I("Total size", nil, s.UniqueBlobSize, binary, "B", 10e9),
 				),
 
 				S(
 					"Annotated tags",
-					I("Count", nil, s.UniqueTagCount, counts.MetricPrefixes, " ", 25e3),
+					I("Count", nil, s.UniqueTagCount, metric, " ", 25e3),
 				),
 
 				S(
 					"References",
-					I("Count", nil, s.ReferenceCount, counts.MetricPrefixes, " ", 25e3),
+					I("Count", nil, s.ReferenceCount, metric, " ", 25e3),
 				),
 			),
 
 			S("Biggest objects",
 				S("Commits",
-					I("Maximum size", s.MaxCommitSizeCommit, s.MaxCommitSize, counts.BinaryPrefixes, "B", 50e3),
-					I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, counts.MetricPrefixes, " ", 10),
+					I("Maximum size", s.MaxCommitSizeCommit, s.MaxCommitSize, binary, "B", 50e3),
+					I("Maximum parents", s.MaxParentCountCommit, s.MaxParentCount, metric, " ", 10),
 				),
 
 				S("Trees",
-					I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, counts.MetricPrefixes, " ", 1000),
+					I("Maximum entries", s.MaxTreeEntriesTree, s.MaxTreeEntries, metric, " ", 1000),
 				),
 
 				S("Blobs",
-					I("Maximum size", s.MaxBlobSizeBlob, s.MaxBlobSize, counts.BinaryPrefixes, "B", 10e6),
+					I("Maximum size", s.MaxBlobSizeBlob, s.MaxBlobSize, binary, "B", 10e6),
 				),
 			),
 
 			S("History structure",
-				I("Maximum history depth", nil, s.MaxHistoryDepth, counts.MetricPrefixes, " ", 500e3),
-				I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, counts.MetricPrefixes, " ", 1.001),
+				I("Maximum history depth", nil, s.MaxHistoryDepth, metric, " ", 500e3),
+				I("Maximum tag depth", s.MaxTagDepthTag, s.MaxTagDepth, metric, " ", 1.001),
 			),
 
 			S("Biggest checkouts",
-				I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, counts.MetricPrefixes, " ", 2000),
-				I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, counts.MetricPrefixes, " ", 10),
-				I("Maximum path length", s.MaxPathLengthTree, s.MaxPathLength, counts.BinaryPrefixes, "B", 100),
+				I("Number of directories", s.MaxExpandedTreeCountTree, s.MaxExpandedTreeCount, metric, " ", 2000),
+				I("Maximum path depth", s.MaxPathDepthTree, s.MaxPathDepth, metric, " ", 10),
+				I("Maximum path length", s.MaxPathLengthTree, s.MaxPathLength, binary, "B", 100),
 
-				I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, counts.MetricPrefixes, " ", 50e3),
-				I("Total size of files", s.MaxExpandedBlobSizeTree, s.MaxExpandedBlobSize, counts.BinaryPrefixes, "B", 1e9),
+				I("Number of files", s.MaxExpandedBlobCountTree, s.MaxExpandedBlobCount, metric, " ", 50e3),
+				I("Total size of files", s.MaxExpandedBlobSizeTree, s.MaxExpandedBlobSize, binary, "B", 1e9),
 
-				I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, counts.MetricPrefixes, " ", 25e3),
+				I("Number of symlinks", s.MaxExpandedLinkCountTree, s.MaxExpandedLinkCount, metric, " ", 25e3),
 
-				I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, counts.MetricPrefixes, " ", 100),
+				I("Number of submodules", s.MaxExpandedSubmoduleCountTree, s.MaxExpandedSubmoduleCount, metric, " ", 100),
 			),
 		),
 		threshold:       threshold,


### PR DESCRIPTION
I've been dabbling with teaching `git-sizer` to emit more useful JSON output. I'd like some feedback.

The existing JSON output is pretty amorphous:

```
{
    "unique_commit_count": 88935,
    "unique_commit_size": 45535158,
    "max_commit_size": 11980,
    "max_commit": "433860f3d0beb0c6f205290bd16cda413148f098",
    "max_history_depth": 18777,
    "max_parent_count": 6,
    "max_parent_count_commit": "d425142e2a045a9dd7879d028ec68bd748df48a3",
    "unique_tree_count": 229664,
    "unique_tree_size": 1666910598,
    "unique_tree_entries": 42170089,
    "max_tree_entries": 923,
    "max_tree_entries_tree": "9a5b0550be325ee2bac70e848564c1366fa407a5 (refs/remotes/upstream/pu:t)",
    "unique_blob_count": 160558,
    "unique_blob_size": 2998423433,
    "max_blob_size": 706886,
    "max_blob_size_blob": "8f9b6fd42b29e33bb647bcacfa088a1eadd83929 (ee4286e8a3022a04e17667a9f54512d6fb1bae29:po/bg.po)",
    "unique_tag_count": 695,
    "max_tag_depth": 2,
    "max_tag_depth_tag": "5f4cd4ca015dc795b9f7f4fed11b3f80a60ac175 (refs/tags/v1.0rc1)",
    "reference_count": 2322,
    "max_path_depth": 7,
    "max_path_depth_tree": "99f3bb2724329e6c039c310226a2aa9579864594 (refs/remotes/upstream/pu^{tree})",
    "max_path_length": 85,
    "max_path_length_tree": "99f3bb2724329e6c039c310226a2aa9579864594 (refs/remotes/upstream/pu^{tree})",
    "max_expanded_tree_count": 45736,
    "max_expanded_tree_count_tree": "d4f8cdd15e4f09eaedc28481e11f5203e6090ef1 (refs/notes/amlog^{tree})",
    "max_expanded_blob_count": 77506,
    "max_expanded_blob_count_tree": "d4f8cdd15e4f09eaedc28481e11f5203e6090ef1 (refs/notes/amlog^{tree})",
    "max_expanded_blob_size": 28803778,
    "max_expanded_blob_size_tree": "99f3bb2724329e6c039c310226a2aa9579864594 (refs/remotes/upstream/pu^{tree})",
    "max_expanded_link_count": 2,
    "max_expanded_link_count_tree": "f74ada36ac7846652dc204d1b30f90c482772a57 (603ee0f0c3d1b8fc09929d185817c43e231317e7^{tree})",
    "max_expanded_submodule_count": 1,
    "max_expanded_submodule_count_tree": "99f3bb2724329e6c039c310226a2aa9579864594 (refs/remotes/upstream/pu^{tree})"
}
```

Problems:

* There is no useful internal structure
* Numbers (measured values) and strings (the IDs of the objects with those values) are jumbled together
* OIDs and descriptions are not separated out
* There is no way to determine level of concern
* The units and prefixes are not available

It would be nice if the JSON output were more self-describing and include the missing information. I propose that it be structured as a map from name to "statistic", where each "statistic" includes

* A prose description of the value
* The numerical value
* The units
* Which prefixes should be used with the units (i.e., metric or binary)
* The "reference value" that is compared against the actual value to determine the level of concern
* The level of concern itself, as a floating-point number
* The OID of the object (if applicable)
* A `git describe`-like name for the object (if applicable)

This would look like the following (edited for size):

```
{
    "maxBlobSize": {
        "Description": "The size of the largest blob object",
        "Value": 706886,
        "Unit": "B",
        "Prefixes": "binary",
        "ReferenceValue": 10000000,
        "LevelOfConcern": 0.0706886,
        "ObjectName": "8f9b6fd42b29e33bb647bcacfa088a1eadd83929",
        "ObjectDescription": "ee4286e8a3022a04e17667a9f54512d6fb1bae29:po/bg.po"
    },
    "maxCheckoutBlobCount": {
        "Description": "The maximum number of files in any checkout",
        "Value": 77506,
        "Unit": "",
        "Prefixes": "metric",
        "ReferenceValue": 50000,
        "LevelOfConcern": 1.55012,
        "ObjectName": "d4f8cdd15e4f09eaedc28481e11f5203e6090ef1",
        "ObjectDescription": "refs/notes/amlog^{tree}"
    },
    [...]
    "maxHistoryDepth": {
        "Description": "The longest chain of commits in history",
        "Value": 18777,
        "Unit": "",
        "Prefixes": "metric",
        "ReferenceValue": 500000,
        "LevelOfConcern": 0.037554
    },
    [...],
    "referenceCount": {
        "Description": "The total number of references",
        "Value": 2322,
        "Unit": "",
        "Prefixes": "metric",
        "ReferenceValue": 25000,
        "LevelOfConcern": 0.09288
    },
    [...]
}
```

The idea is that this should include enough information to build, for example, a GUI incorporating this output without having to know much more about it. What do people think?

In particular,

* Do you like the format?
* Should there be more internal structure (e.g., group items into categories like the top-level categories in the table output)?
* Have I forgotten anything important?
* Should this replace the existing JSON output, or (in the name of backwards compatibility) do you think we have to continue to support the existing JSON output, too?

Fixes #43.

/cc @dimapasko, @peff, @ttaylorr, @larsxschneider
