### PR TITLE
Return success on `git-sizer --help`

### DIFF
--- a/git-sizer.go
+++ b/git-sizer.go
@@ -116,6 +116,9 @@ func mainImplementation() error {
 
 	err = flags.Parse(os.Args[1:])
 	if err != nil {
+		if err == pflag.ErrHelp {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
If the user explicitly asked for help, and that's what they got, then everybody's happy.

Fixes: #71

/cc @Dentrax
