### PR TITLE
Add support for building on and for Darwin:arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin
 /releases
+/vendor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Make sure that your code is formatted correctly: `make gofmt`.
+- Make sure that your code is formatted correctly according to `go fmt`: `go fmt .`.
 - Write tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ $(eval $(call PLATFORM_template,linux,386))
 
 $(eval $(call PLATFORM_template,darwin,386))
 $(eval $(call PLATFORM_template,darwin,amd64))
+$(eval $(call PLATFORM_template,darwin,arm64))
 
 $(eval $(call PLATFORM_template,windows,amd64,.exe))
 $(eval $(call PLATFORM_template,windows,386,.exe))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ GO111MODULES := 1
 export GO111MODULES
 
 GO := $(CURDIR)/script/go
-GOFMT := $(CURDIR)/script/gofmt
 
 GO_LDFLAGS := -X main.BuildVersion=$(shell git describe --tags --always --dirty || echo unknown)
 GOFLAGS := -ldflags "$(GO_LDFLAGS)"
@@ -11,14 +10,6 @@ GOFLAGS := -ldflags "$(GO_LDFLAGS)"
 ifdef USE_ISATTY
 GOFLAGS := $(GOFLAGS) --tags isatty
 endif
-
-GO_SRCS := $(sort $(shell $(GO) list -f ' \
-	{{$$ip := .Dir}} \
-	{{range .GoFiles     }}{{printf "%s/%s\n" $$ip .}}{{end}} \
-	{{range .CgoFiles    }}{{printf "%s/%s\n" $$ip .}}{{end}} \
-	{{range .TestGoFiles }}{{printf "%s/%s\n" $$ip .}}{{end}} \
-	{{range .XTestGoFiles}}{{printf "%s/%s\n" $$ip .}}{{end}} \
-	' ./...))
 
 .PHONY: all
 all: bin/git-sizer
@@ -85,23 +76,6 @@ test: bin/git-sizer gotest
 gotest:
 	$(GO) test -timeout 60s $(GOFLAGS) ./...
 
-.PHONY: gofmt
-gofmt:
-	$(GOFMT) -l -w $(GO_SRCS) | sed -e 's/^/Fixing /'
-
-.PHONY: goimports
-goimports:
-	goimports -l -w -e $(GO_SRCS)
-
-.PHONY: govet
-govet:
-	$(GO) vet ./...
-
 .PHONY: clean
 clean:
 	rm -rf bin
-
-# List all of this project's Go sources:
-.PHONY: srcs
-srcs:
-	@printf "%s\n" $(GO_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO111MODULES
 GO := $(CURDIR)/script/go
 
 GO_LDFLAGS := -X main.BuildVersion=$(shell git describe --tags --always --dirty || echo unknown)
-GOFLAGS := -ldflags "$(GO_LDFLAGS)"
+GOFLAGS := -mod=readonly -ldflags "$(GO_LDFLAGS)"
 
 ifdef USE_ISATTY
 GOFLAGS := $(GOFLAGS) --tags isatty

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: bin/git-sizer
 .PHONY: bin/git-sizer
 bin/git-sizer:
 	mkdir -p bin
-	$(GO) build $(GOFLAGS) -o $@ $(PACKAGE)
+	$(GO) build $(GOFLAGS) -o $@ .
 
 # Cross-compile for a bunch of common platforms. Note that this
 # doesn't work with USE_ISATTY:
@@ -50,7 +50,7 @@ define PLATFORM_template =
 .PHONY: bin/git-sizer-$(1)-$(2)$(3)
 bin/git-sizer-$(1)-$(2)$(3):
 	mkdir -p bin
-	GOOS=$(1) GOARCH=$(2) $$(GO) build $$(GOFLAGS) -ldflags "-X main.ReleaseVersion=$$(VERSION)" -o $$@ $$(PACKAGE)
+	GOOS=$(1) GOARCH=$(2) $$(GO) build $$(GOFLAGS) -ldflags "-X main.ReleaseVersion=$$(VERSION)" -o $$@ .
 common-platforms: bin/git-sizer-$(1)-$(2)$(3)
 
 # Note that releases don't include code from vendor (they're only used

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ endef
 $(eval $(call PLATFORM_template,linux,amd64))
 $(eval $(call PLATFORM_template,linux,386))
 
-$(eval $(call PLATFORM_template,darwin,386))
 $(eval $(call PLATFORM_template,darwin,amd64))
 $(eval $(call PLATFORM_template,darwin,arm64))
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -25,7 +25,7 @@ This procedure is intended for experts and people who want to help develop `git-
         git clone https://github.com/github/git-sizer.git
         cd git-sizer
 
-2.  Install Go if necessary and create and prepare a project-local `GOPATH`:
+2.  Install Go if necessary:
 
         script/bootstrap
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/git-sizer
 
-go 1.13
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/script/ensure-go-installed.sh
+++ b/script/ensure-go-installed.sh
@@ -4,17 +4,17 @@ if [ -z "$ROOTDIR" ]; then
     echo 1>&2 'ensure-go-installed.sh invoked without ROOTDIR set!'
 fi
 
-# Is go installed, and at least 1.13?
+# Is go installed, and at least 1.16?
 go_ok() {
     set -- $(go version 2>/dev/null |
                 sed -n 's/.*go\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2/p' |
                 head -n 1)
-    [ $# -eq 2 ] && [ "$1" -eq 1 ] && [ "$2" -ge 13 ]
+    [ $# -eq 2 ] && [ "$1" -eq 1 ] && [ "$2" -ge 16 ]
 }
 
 # If a local go is installed, use it.
 set_up_vendored_go() {
-    GO_VERSION=go1.13.4
+    GO_VERSION=go1.16.3
     VENDORED_GOROOT="$ROOTDIR/vendor/$GO_VERSION/go"
     if [ -x "$VENDORED_GOROOT/bin/go" ]; then
         export GOROOT="$VENDORED_GOROOT"

--- a/script/install-vendored-go
+++ b/script/install-vendored-go
@@ -3,17 +3,21 @@
 # The checksums below must correspond to the downloads for this version.
 GO_VERSION=go1.16.3
 
-if [ $(uname -s) = "Darwin" ]; then
-    GO_PKG=${GO_VERSION}.darwin-amd64.tar.gz
-    GO_PKG_SHA=f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f
-elif [ $(uname -s) = "Linux" ]; then
+case "$(uname -s):$(uname -m)" in
+Linux:x86_64)
     GO_PKG=${GO_VERSION}.linux-amd64.tar.gz
     GO_PKG_SHA=951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
-else
+    ;;
+Darwin:x86_64)
+    GO_PKG=${GO_VERSION}.darwin-amd64.tar.gz
+    GO_PKG_SHA=6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac
+    ;;
+*)
     echo 1>&2 "I don't know how to install Go on your platform."
     echo 1>&2 "Please install $GO_VERSION or later and add it to your PATH."
     exit 1
-fi
+    ;;
+esac
 
 archivesum() {
     shasum -a256 "$ARCHIVE"

--- a/script/install-vendored-go
+++ b/script/install-vendored-go
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 # The checksums below must correspond to the downloads for this version.
-GO_VERSION=go1.13.4
+GO_VERSION=go1.16.3
 
 if [ $(uname -s) = "Darwin" ]; then
     GO_PKG=${GO_VERSION}.darwin-amd64.tar.gz
-    GO_PKG_SHA=9f0721551a24a1eb43d2005cd58bd7b17574e50384b8da8896b0754259790752
+    GO_PKG_SHA=f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f
 elif [ $(uname -s) = "Linux" ]; then
     GO_PKG=${GO_VERSION}.linux-amd64.tar.gz
-    GO_PKG_SHA=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
+    GO_PKG_SHA=951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
 else
     echo 1>&2 "I don't know how to install Go on your platform."
     echo 1>&2 "Please install $GO_VERSION or later and add it to your PATH."

--- a/script/install-vendored-go
+++ b/script/install-vendored-go
@@ -12,6 +12,10 @@ Darwin:x86_64)
     GO_PKG=${GO_VERSION}.darwin-amd64.tar.gz
     GO_PKG_SHA=6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac
     ;;
+Darwin:arm64)
+    GO_PKG=${GO_VERSION}.darwin-arm64.tar.gz
+    GO_PKG_SHA=f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f
+    ;;
 *)
     echo 1>&2 "I don't know how to install Go on your platform."
     echo 1>&2 "Please install $GO_VERSION or later and add it to your PATH."


### PR DESCRIPTION
Update to Go 1.16.3, which includes support for Darwin:arm64. On the other hand, Darwin:386 is no longer supported, so remove that from the list of releases that we build.

Fixes #68

/cc @dbast, who requested this.
