### PR TITLE
Better decouple the test from the runtime code

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -522,17 +522,6 @@ func (repo *Repository) CreateObject(t ObjectType, writer func(io.Writer) error)
 	return NewOID(string(bytes.TrimSpace(output)))
 }
 
-func (repo *Repository) UpdateRef(refname string, oid OID) error {
-	var cmd *exec.Cmd
-
-	if oid == NullOID {
-		cmd = repo.gitCommand("update-ref", "-d", refname)
-	} else {
-		cmd = repo.gitCommand("update-ref", refname, oid.String())
-	}
-	return cmd.Run()
-}
-
 // Next returns the next object, or EOF when done.
 func (l *ObjectIter) Next() (OID, ObjectType, counts.Count32, error) {
 	line, err := l.f.ReadString('\n')

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -26,6 +26,8 @@ func TestExec(t *testing.T) {
 }
 
 func gitCommand(t *testing.T, repo *git.Repository, args ...string) *exec.Cmd {
+	t.Helper()
+
 	cmd := exec.Command("git", args...)
 	cmd.Env = append(os.Environ(), "GIT_DIR="+repo.Path())
 	return cmd

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -33,6 +33,19 @@ func gitCommand(t *testing.T, repoPath string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+func updateRef(t *testing.T, repoPath string, refname string, oid git.OID) error {
+	t.Helper()
+
+	var cmd *exec.Cmd
+
+	if oid == git.NullOID {
+		cmd = gitCommand(t, repoPath, "update-ref", "-d", refname)
+	} else {
+		cmd = gitCommand(t, repoPath, "update-ref", refname, oid.String())
+	}
+	return cmd.Run()
+}
+
 func addFile(t *testing.T, repoPath string, repo *git.Repository, relativePath, contents string) {
 	dirPath := filepath.Dir(relativePath)
 	if dirPath != "." {
@@ -119,7 +132,7 @@ func newGitBomb(
 	})
 	require.NoError(t, err)
 
-	err = repo.UpdateRef("refs/heads/master", oid)
+	err = updateRef(t, repo.Path(), "refs/heads/master", oid)
 	require.NoError(t, err)
 
 	return repo

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -128,7 +128,7 @@ func newGitBomb(
 	repo, err = git.NewRepository(path)
 	require.NoError(t, err)
 
-	oid := createObject(t, repo.Path(), "blob", func(w io.Writer) error {
+	oid := createObject(t, path, "blob", func(w io.Writer) error {
 		_, err := io.WriteString(w, body)
 		return err
 	})
@@ -139,7 +139,7 @@ func newGitBomb(
 	prefix := "f"
 
 	for ; depth > 0; depth-- {
-		oid = createObject(t, repo.Path(), "tree", func(w io.Writer) error {
+		oid = createObject(t, path, "tree", func(w io.Writer) error {
 			for i := 0; i < breadth; i++ {
 				_, err = fmt.Fprintf(
 					w, "%s %s%0*d\x00%s",
@@ -156,7 +156,7 @@ func newGitBomb(
 		prefix = "d"
 	}
 
-	oid = createObject(t, repo.Path(), "commit", func(w io.Writer) error {
+	oid = createObject(t, path, "commit", func(w io.Writer) error {
 		_, err := fmt.Fprintf(
 			w,
 			"tree %s\n"+
@@ -169,7 +169,7 @@ func newGitBomb(
 		return err
 	})
 
-	err = updateRef(t, repo.Path(), "refs/heads/master", oid)
+	err = updateRef(t, path, "refs/heads/master", oid)
 	require.NoError(t, err)
 
 	return repo

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -110,7 +110,7 @@ func newGitBomb(
 				"author Example <example@example.com> 1112911993 -0700\n"+
 				"committer Example <example@example.com> 1112911993 -0700\n"+
 				"\n"+
-				"Mwahahaha!\n",
+				"Test git bomb\n",
 			oid,
 		)
 		return err
@@ -152,8 +152,8 @@ func TestBomb(t *testing.T) {
 	}
 
 	assert.Equal(counts.Count32(1), h.UniqueCommitCount, "unique commit count")
-	assert.Equal(counts.Count64(169), h.UniqueCommitSize, "unique commit size")
-	assert.Equal(counts.Count32(169), h.MaxCommitSize, "max commit size")
+	assert.Equal(counts.Count64(172), h.UniqueCommitSize, "unique commit size")
+	assert.Equal(counts.Count32(172), h.MaxCommitSize, "max commit size")
 	assert.Equal("refs/heads/master", h.MaxCommitSizeCommit.Path(), "max commit size commit")
 	assert.Equal(counts.Count32(1), h.MaxHistoryDepth, "max history depth")
 	assert.Equal(counts.Count32(0), h.MaxParentCount, "max parent count")

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -25,11 +25,11 @@ func TestExec(t *testing.T) {
 	assert.NoErrorf(t, err, "command failed; output: %#v", string(output))
 }
 
-func gitCommand(t *testing.T, repo *git.Repository, args ...string) *exec.Cmd {
+func gitCommand(t *testing.T, repoPath string, args ...string) *exec.Cmd {
 	t.Helper()
 
 	cmd := exec.Command("git", args...)
-	cmd.Env = append(os.Environ(), "GIT_DIR="+repo.Path())
+	cmd.Env = append(os.Environ(), "GIT_DIR="+repoPath)
 	return cmd
 }
 
@@ -46,7 +46,7 @@ func addFile(t *testing.T, repoPath string, repo *git.Repository, relativePath, 
 	require.NoErrorf(t, err, "writing to file %q", filename)
 	require.NoErrorf(t, f.Close(), "closing file %q", filename)
 
-	cmd := gitCommand(t, repo, "add", relativePath)
+	cmd := gitCommand(t, repo.Path(), "add", relativePath)
 	cmd.Dir = repoPath
 	require.NoErrorf(t, cmd.Run(), "adding file %q", relativePath)
 }
@@ -207,21 +207,21 @@ func TestTaggedTags(t *testing.T) {
 
 	timestamp := time.Unix(1112911993, 0)
 
-	cmd = gitCommand(t, repo, "commit", "-m", "initial", "--allow-empty")
+	cmd = gitCommand(t, repo.Path(), "commit", "-m", "initial", "--allow-empty")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating commit")
 
 	// The lexicographical order of these tags is important, hence
 	// their strange names.
-	cmd = gitCommand(t, repo, "tag", "-m", "tag 1", "tag", "master")
+	cmd = gitCommand(t, repo.Path(), "tag", "-m", "tag 1", "tag", "master")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating tag 1")
 
-	cmd = gitCommand(t, repo, "tag", "-m", "tag 2", "bag", "tag")
+	cmd = gitCommand(t, repo.Path(), "tag", "-m", "tag 2", "bag", "tag")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating tag 2")
 
-	cmd = gitCommand(t, repo, "tag", "-m", "tag 3", "wag", "bag")
+	cmd = gitCommand(t, repo.Path(), "tag", "-m", "tag 3", "wag", "bag")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating tag 3")
 
@@ -250,7 +250,7 @@ func TestFromSubdir(t *testing.T) {
 
 	addFile(t, path, repo, "subdir/file.txt", "Hello, world!\n")
 
-	cmd = gitCommand(t, repo, "commit", "-m", "initial")
+	cmd = gitCommand(t, repo.Path(), "commit", "-m", "initial")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating commit")
 
@@ -283,7 +283,7 @@ func TestSubmodule(t *testing.T) {
 	addFile(t, submPath, submRepo, "submfile2.txt", "Hello again, submodule!\n")
 	addFile(t, submPath, submRepo, "submfile3.txt", "Hello again, submodule!\n")
 
-	cmd = gitCommand(t, submRepo, "commit", "-m", "subm initial")
+	cmd = gitCommand(t, submRepo.Path(), "commit", "-m", "subm initial")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating subm commit")
 
@@ -294,16 +294,16 @@ func TestSubmodule(t *testing.T) {
 	require.NoError(t, err, "initializing main Repository object")
 	addFile(t, mainPath, mainRepo, "mainfile.txt", "Hello, main!\n")
 
-	cmd = gitCommand(t, mainRepo, "commit", "-m", "main initial")
+	cmd = gitCommand(t, mainRepo.Path(), "commit", "-m", "main initial")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "creating main commit")
 
 	// Make subm a submodule of main:
-	cmd = gitCommand(t, mainRepo, "submodule", "add", submPath, "sub")
+	cmd = gitCommand(t, mainRepo.Path(), "submodule", "add", submPath, "sub")
 	cmd.Dir = mainPath
 	require.NoError(t, cmd.Run(), "adding submodule")
 
-	cmd = gitCommand(t, mainRepo, "commit", "-m", "add submodule")
+	cmd = gitCommand(t, mainRepo.Path(), "commit", "-m", "add submodule")
 	addAuthorInfo(cmd, &timestamp)
 	require.NoError(t, cmd.Run(), "committing submodule to main")
 

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -48,8 +48,9 @@ func updateRef(t *testing.T, repoPath string, refname string, oid git.OID) error
 }
 
 // CreateObject creates a new Git object, of the specified type, in
-// `Repository`. `writer` is a function that writes the object in `git
-// hash-object` input format. This is used for testing only.
+// the repository at `repoPath`. `writer` is a function that writes
+// the object in `git hash-object` input format. This is used for
+// testing only.
 func createObject(
 	t *testing.T, repoPath string, otype git.ObjectType, writer func(io.Writer) error,
 ) git.OID {
@@ -86,7 +87,7 @@ func createObject(
 	return oid
 }
 
-func addFile(t *testing.T, repoPath string, repo *git.Repository, relativePath, contents string) {
+func addFile(t *testing.T, repoPath string, relativePath, contents string) {
 	dirPath := filepath.Dir(relativePath)
 	if dirPath != "." {
 		require.NoError(t, os.MkdirAll(filepath.Join(repoPath, dirPath), 0777), "creating subdir")
@@ -292,12 +293,10 @@ func TestFromSubdir(t *testing.T) {
 
 	cmd := exec.Command("git", "init", path)
 	require.NoError(t, cmd.Run(), "initializing repo")
-	repo, err := git.NewRepository(path)
-	require.NoError(t, err, "initializing Repository object")
 
 	timestamp := time.Unix(1112911993, 0)
 
-	addFile(t, path, repo, "subdir/file.txt", "Hello, world!\n")
+	addFile(t, path, "subdir/file.txt", "Hello, world!\n")
 
 	cmd = gitCommand(t, path, "commit", "-m", "initial")
 	addAuthorInfo(cmd, &timestamp)
@@ -326,11 +325,9 @@ func TestSubmodule(t *testing.T) {
 	submPath := filepath.Join(path, "subm")
 	cmd := exec.Command("git", "init", submPath)
 	require.NoError(t, cmd.Run(), "initializing subm repo")
-	submRepo, err := git.NewRepository(submPath)
-	require.NoError(t, err, "initializing subm Repository object")
-	addFile(t, submPath, submRepo, "submfile1.txt", "Hello, submodule!\n")
-	addFile(t, submPath, submRepo, "submfile2.txt", "Hello again, submodule!\n")
-	addFile(t, submPath, submRepo, "submfile3.txt", "Hello again, submodule!\n")
+	addFile(t, submPath, "submfile1.txt", "Hello, submodule!\n")
+	addFile(t, submPath, "submfile2.txt", "Hello again, submodule!\n")
+	addFile(t, submPath, "submfile3.txt", "Hello again, submodule!\n")
 
 	cmd = gitCommand(t, submPath, "commit", "-m", "subm initial")
 	addAuthorInfo(cmd, &timestamp)
@@ -341,7 +338,7 @@ func TestSubmodule(t *testing.T) {
 	require.NoError(t, cmd.Run(), "initializing main repo")
 	mainRepo, err := git.NewRepository(mainPath)
 	require.NoError(t, err, "initializing main Repository object")
-	addFile(t, mainPath, mainRepo, "mainfile.txt", "Hello, main!\n")
+	addFile(t, mainPath, "mainfile.txt", "Hello, main!\n")
 
 	cmd = gitCommand(t, mainPath, "commit", "-m", "main initial")
 	addAuthorInfo(cmd, &timestamp)

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -133,7 +133,6 @@ func pow(x uint64, n int) uint64 {
 
 func TestBomb(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
 
 	path, err := ioutil.TempDir("", "bomb")
 	require.NoError(t, err)
@@ -147,49 +146,47 @@ func TestBomb(t *testing.T) {
 	h, err := sizes.ScanRepositoryUsingGraph(
 		repo, git.AllReferencesFilter, sizes.NameStyleFull, false,
 	)
-	if !assert.NoError(err) {
-		return
-	}
+	require.NoError(t, err)
 
-	assert.Equal(counts.Count32(1), h.UniqueCommitCount, "unique commit count")
-	assert.Equal(counts.Count64(172), h.UniqueCommitSize, "unique commit size")
-	assert.Equal(counts.Count32(172), h.MaxCommitSize, "max commit size")
-	assert.Equal("refs/heads/master", h.MaxCommitSizeCommit.Path(), "max commit size commit")
-	assert.Equal(counts.Count32(1), h.MaxHistoryDepth, "max history depth")
-	assert.Equal(counts.Count32(0), h.MaxParentCount, "max parent count")
-	assert.Equal("refs/heads/master", h.MaxParentCountCommit.Path(), "max parent count commit")
+	assert.Equal(t, counts.Count32(1), h.UniqueCommitCount, "unique commit count")
+	assert.Equal(t, counts.Count64(172), h.UniqueCommitSize, "unique commit size")
+	assert.Equal(t, counts.Count32(172), h.MaxCommitSize, "max commit size")
+	assert.Equal(t, "refs/heads/master", h.MaxCommitSizeCommit.Path(), "max commit size commit")
+	assert.Equal(t, counts.Count32(1), h.MaxHistoryDepth, "max history depth")
+	assert.Equal(t, counts.Count32(0), h.MaxParentCount, "max parent count")
+	assert.Equal(t, "refs/heads/master", h.MaxParentCountCommit.Path(), "max parent count commit")
 
-	assert.Equal(counts.Count32(10), h.UniqueTreeCount, "unique tree count")
-	assert.Equal(counts.Count64(2910), h.UniqueTreeSize, "unique tree size")
-	assert.Equal(counts.Count64(100), h.UniqueTreeEntries, "unique tree entries")
-	assert.Equal(counts.Count32(10), h.MaxTreeEntries, "max tree entries")
-	assert.Equal("refs/heads/master:d0/d0/d0/d0/d0/d0/d0/d0/d0", h.MaxTreeEntriesTree.Path(), "max tree entries tree")
+	assert.Equal(t, counts.Count32(10), h.UniqueTreeCount, "unique tree count")
+	assert.Equal(t, counts.Count64(2910), h.UniqueTreeSize, "unique tree size")
+	assert.Equal(t, counts.Count64(100), h.UniqueTreeEntries, "unique tree entries")
+	assert.Equal(t, counts.Count32(10), h.MaxTreeEntries, "max tree entries")
+	assert.Equal(t, "refs/heads/master:d0/d0/d0/d0/d0/d0/d0/d0/d0", h.MaxTreeEntriesTree.Path(), "max tree entries tree")
 
-	assert.Equal(counts.Count32(1), h.UniqueBlobCount, "unique blob count")
-	assert.Equal(counts.Count64(6), h.UniqueBlobSize, "unique blob size")
-	assert.Equal(counts.Count32(6), h.MaxBlobSize, "max blob size")
-	assert.Equal("refs/heads/master:d0/d0/d0/d0/d0/d0/d0/d0/d0/f0", h.MaxBlobSizeBlob.Path(), "max blob size blob")
+	assert.Equal(t, counts.Count32(1), h.UniqueBlobCount, "unique blob count")
+	assert.Equal(t, counts.Count64(6), h.UniqueBlobSize, "unique blob size")
+	assert.Equal(t, counts.Count32(6), h.MaxBlobSize, "max blob size")
+	assert.Equal(t, "refs/heads/master:d0/d0/d0/d0/d0/d0/d0/d0/d0/f0", h.MaxBlobSizeBlob.Path(), "max blob size blob")
 
-	assert.Equal(counts.Count32(0), h.UniqueTagCount, "unique tag count")
-	assert.Equal(counts.Count32(0), h.MaxTagDepth, "max tag depth")
+	assert.Equal(t, counts.Count32(0), h.UniqueTagCount, "unique tag count")
+	assert.Equal(t, counts.Count32(0), h.MaxTagDepth, "max tag depth")
 
-	assert.Equal(counts.Count32(1), h.ReferenceCount, "reference count")
+	assert.Equal(t, counts.Count32(1), h.ReferenceCount, "reference count")
 
-	assert.Equal(counts.Count32(10), h.MaxPathDepth, "max path depth")
-	assert.Equal("refs/heads/master^{tree}", h.MaxPathDepthTree.Path(), "max path depth tree")
-	assert.Equal(counts.Count32(29), h.MaxPathLength, "max path length")
-	assert.Equal("refs/heads/master^{tree}", h.MaxPathLengthTree.Path(), "max path length tree")
+	assert.Equal(t, counts.Count32(10), h.MaxPathDepth, "max path depth")
+	assert.Equal(t, "refs/heads/master^{tree}", h.MaxPathDepthTree.Path(), "max path depth tree")
+	assert.Equal(t, counts.Count32(29), h.MaxPathLength, "max path length")
+	assert.Equal(t, "refs/heads/master^{tree}", h.MaxPathLengthTree.Path(), "max path length tree")
 
-	assert.Equal(counts.Count32((pow(10, 10)-1)/(10-1)), h.MaxExpandedTreeCount, "max expanded tree count")
-	assert.Equal("refs/heads/master^{tree}", h.MaxExpandedTreeCountTree.Path(), "max expanded tree count tree")
-	assert.Equal(counts.Count32(0xffffffff), h.MaxExpandedBlobCount, "max expanded blob count")
-	assert.Equal("refs/heads/master^{tree}", h.MaxExpandedBlobCountTree.Path(), "max expanded blob count tree")
-	assert.Equal(counts.Count64(6*pow(10, 10)), h.MaxExpandedBlobSize, "max expanded blob size")
-	assert.Equal("refs/heads/master^{tree}", h.MaxExpandedBlobSizeTree.Path(), "max expanded blob size tree")
-	assert.Equal(counts.Count32(0), h.MaxExpandedLinkCount, "max expanded link count")
-	assert.Nil(h.MaxExpandedLinkCountTree, "max expanded link count tree")
-	assert.Equal(counts.Count32(0), h.MaxExpandedSubmoduleCount, "max expanded submodule count")
-	assert.Nil(h.MaxExpandedSubmoduleCountTree, "max expanded submodule count tree")
+	assert.Equal(t, counts.Count32((pow(10, 10)-1)/(10-1)), h.MaxExpandedTreeCount, "max expanded tree count")
+	assert.Equal(t, "refs/heads/master^{tree}", h.MaxExpandedTreeCountTree.Path(), "max expanded tree count tree")
+	assert.Equal(t, counts.Count32(0xffffffff), h.MaxExpandedBlobCount, "max expanded blob count")
+	assert.Equal(t, "refs/heads/master^{tree}", h.MaxExpandedBlobCountTree.Path(), "max expanded blob count tree")
+	assert.Equal(t, counts.Count64(6*pow(10, 10)), h.MaxExpandedBlobSize, "max expanded blob size")
+	assert.Equal(t, "refs/heads/master^{tree}", h.MaxExpandedBlobSizeTree.Path(), "max expanded blob size tree")
+	assert.Equal(t, counts.Count32(0), h.MaxExpandedLinkCount, "max expanded link count")
+	assert.Nil(t, h.MaxExpandedLinkCountTree, "max expanded link count tree")
+	assert.Equal(t, counts.Count32(0), h.MaxExpandedSubmoduleCount, "max expanded submodule count")
+	assert.Nil(t, h.MaxExpandedSubmoduleCountTree, "max expanded submodule count tree")
 }
 
 func TestTaggedTags(t *testing.T) {

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -62,21 +62,12 @@ func addAuthorInfo(cmd *exec.Cmd, timestamp *time.Time) {
 }
 
 func newGitBomb(
-	t *testing.T, repoName string, depth, breadth int, body string,
+	t *testing.T, path string, depth, breadth int, body string,
 ) (repo *git.Repository) {
 	t.Helper()
 
-	path, err := ioutil.TempDir("", repoName)
-	require.NoError(t, err)
-
-	defer func() {
-		if err != nil {
-			os.RemoveAll(path)
-		}
-	}()
-
 	cmd := exec.Command("git", "init", "--bare", path)
-	err = cmd.Run()
+	err := cmd.Run()
 	require.NoError(t, err)
 
 	repo, err = git.NewRepository(path)
@@ -144,8 +135,14 @@ func TestBomb(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	repo := newGitBomb(t, "bomb", 10, 10, "boom!\n")
-	defer os.RemoveAll(repo.Path())
+	path, err := ioutil.TempDir("", "bomb")
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(path)
+	}()
+
+	repo := newGitBomb(t, path, 10, 10, "boom!\n")
 
 	h, err := sizes.ScanRepositoryUsingGraph(
 		repo, git.AllReferencesFilter, sizes.NameStyleFull, false,


### PR DESCRIPTION
* Build and improve the test helper functions.
* Move `updateRef()` and `createObject()` to the test package.
* Don't use `git.Repository` in the test code except when needed to invoke `ScanRepositoryUsingGraph()`.
