### PR TITLE
Add some more reference selection options

### DIFF
--- a/git/ref_filter.go
+++ b/git/ref_filter.go
@@ -18,6 +18,18 @@ const (
 	Exclude
 )
 
+func (p Polarity) Inverted() Polarity {
+	switch p {
+	case Include:
+		return Exclude
+	case Exclude:
+		return Include
+	default:
+		// This shouldn't happen:
+		return Exclude
+	}
+}
+
 // polarizedFilter is a filter that might match, in which case it
 // includes or excludes the reference (according to its polarity). If
 // it doesn't match, then it doesn't say anything about the reference.


### PR DESCRIPTION
Add some more reference selection options. The same functionality could be achieved using the existing options, but it's more convenient to have these dedicated options as shorthand:

* `--no-branches`, `--no-tags`, `--no-remotes` — the opposite of the existing `branches`, `--tags`, and `--remotes` options.
* `--notes` and `--no-notes` — include or exclude `refs/notes/*`.
* `--stash` and `--no-stash` — include or exclude `refs/stash`.

Add tests to cover the new options, driven by a grid of expected results.

/cc @chrisd8088 or @larsxschneider as possible reviewers.
