### PR TITLE
Allow subsets of references to be defined via gitconfig

### DIFF
--- a/git/gitconfig.go
+++ b/git/gitconfig.go
@@ -2,9 +2,91 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 )
+
+type ConfigEntry struct {
+	Key   string
+	Value string
+}
+
+type Config struct {
+	Entries []ConfigEntry
+}
+
+// Config returns the entries from gitconfig. If `prefix` is provided,
+// then only include entries in that section, which must match the at
+// a component boundary (as defined by `configKeyMatchesPrefix()`),
+// and strip off the prefix in the keys that are returned.
+func (repo *Repository) Config(prefix string) (*Config, error) {
+	cmd := repo.gitCommand("config", "--list", "-z")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("reading git configuration: %w", err)
+	}
+
+	var config Config
+
+	for len(out) > 0 {
+		keyEnd := bytes.IndexByte(out, '\n')
+		if keyEnd == -1 {
+			return nil, errors.New("invalid output from 'git config'")
+		}
+		key := string(out[:keyEnd])
+		out = out[keyEnd+1:]
+		valueEnd := bytes.IndexByte(out, 0)
+		if valueEnd == -1 {
+			return nil, errors.New("invalid output from 'git config'")
+		}
+		value := string(out[:valueEnd])
+		out = out[valueEnd+1:]
+
+		ok, rest := configKeyMatchesPrefix(key, prefix)
+		if !ok {
+			continue
+		}
+
+		entry := ConfigEntry{
+			Key:   rest,
+			Value: value,
+		}
+		config.Entries = append(config.Entries, entry)
+	}
+
+	return &config, nil
+}
+
+// configKeyMatchesPrefix checks whether `key` starts with `prefix` at
+// a component boundary (i.e., at a '.'). If yes, it returns `true`
+// and the part of the key after the prefix; e.g.:
+//
+//     configKeyMatchesPrefix("foo.bar", "foo") → true, "bar"
+//     configKeyMatchesPrefix("foo.bar", "foo.") → true, "bar"
+//     configKeyMatchesPrefix("foo.bar", "foo.bar") → true, ""
+//     configKeyMatchesPrefix("foo.bar", "foo.bar.") → false, ""
+func configKeyMatchesPrefix(key, prefix string) (bool, string) {
+	if prefix == "" {
+		return true, key
+	}
+	if !strings.HasPrefix(key, prefix) {
+		return false, ""
+	}
+
+	if prefix[len(prefix)-1] == '.' {
+		return true, key[len(prefix):]
+	}
+	if len(key) == len(prefix) {
+		return true, ""
+	}
+	if key[len(prefix)] == '.' {
+		return true, key[len(prefix)+1:]
+	}
+	return false, ""
+}
 
 func (repo *Repository) ConfigStringDefault(key string, defaultValue string) (string, error) {
 	cmd := repo.gitCommand(

--- a/git/gitconfig_test.go
+++ b/git/gitconfig_test.go
@@ -1,0 +1,36 @@
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigKeyMatchesPrefix(t *testing.T) {
+	for _, p := range []struct {
+		key, prefix    string
+		expectedBool   bool
+		expectedString string
+	}{
+		{"foo.bar", "", true, "foo.bar"},
+		{"foo.bar", "foo", true, "bar"},
+		{"foo.bar", "foo.", true, "bar"},
+		{"foo.bar", "foo.bar", true, ""},
+		{"foo.bar", "foo.bar.", false, ""},
+		{"foo.bar", "foo.bar.baz", false, ""},
+		{"foo.bar", "foo.barbaz", false, ""},
+		{"foo.bar.baz", "foo.bar", true, "baz"},
+		{"foo.barbaz", "foo.bar", false, ""},
+		{"foo.bar", "bar", false, ""},
+	} {
+		t.Run(
+			fmt.Sprintf("TestConfigKeyMatchesPrefix(%q, %q)", p.key, p.prefix),
+			func(t *testing.T) {
+				ok, s := configKeyMatchesPrefix(p.key, p.prefix)
+				assert.Equal(t, p.expectedBool, ok)
+				assert.Equal(t, p.expectedString, s)
+			},
+		)
+	}
+}

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -272,23 +272,70 @@ func TestRefSelections(t *testing.T) {
 		name string
 		args []string
 	}{
-		{"no arguments", nil},                                                  // 0
-		{"branches", []string{"--branches"}},                                   // 1
-		{"no branches", []string{"--no-branches"}},                             // 2
-		{"tags", []string{"--tags"}},                                           // 3
-		{"no tags", []string{"--no-tags"}},                                     // 4
-		{"remotes", []string{"--remotes"}},                                     // 5
-		{"no remotes", []string{"--no-remotes"}},                               // 6
-		{"notes", []string{"--notes"}},                                         // 7
-		{"no notes", []string{"--no-notes"}},                                   // 8
-		{"stash", []string{"--stash"}},                                         // 9
-		{"no stash", []string{"--no-stash"}},                                   // 10
-		{"branches and tags", []string{"--branches", "--tags"}},                // 11
-		{"foo", []string{"--include-regexp", ".*foo.*"}},                       // 12
-		{"refs/foo as prefix", []string{"--include", "refs/foo"}},              // 13
-		{"refs/foo as regexp", []string{"--include-regexp", "refs/foo"}},       // 14
-		{"release tags", []string{"--include-regexp", "refs/tags/release-.*"}}, // 15
-		{
+		{ // 0
+			name: "no arguments",
+		},
+		{ // 1
+			name: "branches",
+			args: []string{"--branches"},
+		},
+		{ // 2
+			name: "no branches",
+			args: []string{"--no-branches"},
+		},
+		{ // 3
+			name: "tags",
+			args: []string{"--tags"},
+		},
+		{ // 4
+			name: "no tags",
+			args: []string{"--no-tags"},
+		},
+		{ // 5
+			name: "remotes",
+			args: []string{"--remotes"},
+		},
+		{ // 6
+			name: "no remotes",
+			args: []string{"--no-remotes"},
+		},
+		{ // 7
+			name: "notes",
+			args: []string{"--notes"},
+		},
+		{ // 8
+			name: "no notes",
+			args: []string{"--no-notes"},
+		},
+		{ // 9
+			name: "stash",
+			args: []string{"--stash"},
+		},
+		{ // 10
+			name: "no stash",
+			args: []string{"--no-stash"},
+		},
+		{ // 11
+			name: "branches and tags",
+			args: []string{"--branches", "--tags"},
+		},
+		{ // 12
+			name: "foo",
+			args: []string{"--include-regexp", ".*foo.*"},
+		},
+		{ // 13
+			name: "refs/foo as prefix",
+			args: []string{"--include", "refs/foo"},
+		},
+		{ // 14
+			name: "refs/foo as regexp",
+			args: []string{"--include-regexp", "refs/foo"},
+		},
+		{ // 15
+			name: "release tags",
+			args: []string{"--include-regexp", "refs/tags/release-.*"},
+		},
+		{ // 16
 			name: "combination",
 			args: []string{
 				"--include=refs/heads",
@@ -298,7 +345,7 @@ func TestRefSelections(t *testing.T) {
 				"--exclude", "refs/foo",
 				"--exclude-regexp", "refs/tags/release-.*",
 			},
-		}, // 16
+		},
 	} {
 		t.Run(
 			p.name,


### PR DESCRIPTION
I thought it would be handy to allow users to define subsets of references via gitconfig, and for those to be usable by `git-sizer` to pick and choose what references to scan. For example, maybe you want to ignore GitHub pull request references?

    [refgroup "no-pull"]
            exclude = refs/pull

then run `git-sizer --refgroup=no-pull`. Or you want a way to scan branches and tags, but not release tags? Try

    [refgroup "normal"]
            include = refs/heads
            include = refs/tags
            excludeRegexp = refs/tags/release-.*

and then run `git sizer --refgroup=normal`.

/cc @terrorobe, @ttaylorr
