### PR TITLE
make default threshold 1 again

### DIFF
--- a/git-sizer.go
+++ b/git-sizer.go
@@ -260,7 +260,7 @@ func mainImplementation(args []string) error {
 	var cpuprofile string
 	var jsonOutput bool
 	var jsonVersion int
-	var threshold sizes.Threshold
+	var threshold sizes.Threshold = 1
 	var progress bool
 	var version bool
 	var filter git.IncludeExcludeFilter


### PR DESCRIPTION
https://github.com/github/git-sizer/pull/83 started allowing some
values to be set through config options.  In the process the default
value for the threshold was lost, which used to be 1, but after the
change was 0.  Set the default threshold to 1 again as is documented.

/cc @mhagger 