### PR TITLE
Don't write directly to `os.Stdout` and `os.Stderr`

### DIFF
--- a/git-sizer.go
+++ b/git-sizer.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"runtime/pprof"
 	"strconv"
+	"time"
 
 	"github.com/spf13/pflag"
 
 	"github.com/github/git-sizer/git"
 	"github.com/github/git-sizer/internal/refopts"
 	"github.com/github/git-sizer/isatty"
+	"github.com/github/git-sizer/meter"
 	"github.com/github/git-sizer/sizes"
 )
 
@@ -269,7 +271,12 @@ func mainImplementation(args []string) error {
 		return err
 	}
 
-	historySize, err := sizes.ScanRepositoryUsingGraph(repo, rg, nameStyle, progress)
+	var progressMeter meter.Progress = meter.NoProgressMeter
+	if progress {
+		progressMeter = meter.NewProgressMeter(os.Stderr, 100*time.Millisecond)
+	}
+
+	historySize, err := sizes.ScanRepositoryUsingGraph(repo, rg, nameStyle, progressMeter)
 	if err != nil {
 		return fmt.Errorf("error scanning repository: %w", err)
 	}

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -108,6 +108,7 @@ func mainImplementation(args []string) error {
 	var threshold sizes.Threshold = 1
 	var progress bool
 	var version bool
+	var showRefs bool
 
 	// Try to open the repository, but it's not an error yet if this
 	// fails, because the user might only be asking for `--help`.
@@ -178,6 +179,8 @@ func mainImplementation(args []string) error {
 	}
 
 	rgb.AddRefopts(flags)
+
+	flags.BoolVar(&showRefs, "show-refs", false, "list the references being processed")
 
 	flags.SortFlags = false
 
@@ -269,6 +272,11 @@ func mainImplementation(args []string) error {
 	rg, err := rgb.Finish()
 	if err != nil {
 		return err
+	}
+
+	if showRefs {
+		fmt.Fprintf(os.Stderr, "References (included references marked with '+'):\n")
+		rg = refopts.NewShowRefGrouper(rg, os.Stderr)
 	}
 
 	var progressMeter meter.Progress = meter.NoProgressMeter

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/github/git-sizer/counts"
 	"github.com/github/git-sizer/git"
 	"github.com/github/git-sizer/internal/testutils"
+	"github.com/github/git-sizer/meter"
 	"github.com/github/git-sizer/sizes"
 )
 
@@ -548,7 +549,7 @@ func TestBomb(t *testing.T) {
 
 	h, err := sizes.ScanRepositoryUsingGraph(
 		repo.Repository(t),
-		refGrouper{}, sizes.NameStyleFull, false,
+		refGrouper{}, sizes.NameStyleFull, meter.NoProgressMeter,
 	)
 	require.NoError(t, err)
 
@@ -621,7 +622,7 @@ func TestTaggedTags(t *testing.T) {
 
 	h, err := sizes.ScanRepositoryUsingGraph(
 		repo.Repository(t),
-		refGrouper{}, sizes.NameStyleNone, false,
+		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
 	assert.Equal(t, counts.Count32(3), h.MaxTagDepth, "tag depth")
@@ -643,7 +644,7 @@ func TestFromSubdir(t *testing.T) {
 
 	h, err := sizes.ScanRepositoryUsingGraph(
 		repo.Repository(t),
-		refGrouper{}, sizes.NameStyleNone, false,
+		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
 	assert.Equal(t, counts.Count32(2), h.MaxPathDepth, "max path depth")
@@ -696,7 +697,7 @@ func TestSubmodule(t *testing.T) {
 	// Analyze the main repo:
 	h, err := sizes.ScanRepositoryUsingGraph(
 		mainRepo.Repository(t),
-		refGrouper{}, sizes.NameStyleNone, false,
+		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
 	assert.Equal(t, counts.Count32(2), h.UniqueBlobCount, "unique blob count")
@@ -709,7 +710,7 @@ func TestSubmodule(t *testing.T) {
 	}
 	h, err = sizes.ScanRepositoryUsingGraph(
 		submRepo2.Repository(t),
-		refGrouper{}, sizes.NameStyleNone, false,
+		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
 	assert.Equal(t, counts.Count32(2), h.UniqueBlobCount, "unique blob count")

--- a/internal/refopts/ref_group_builder.go
+++ b/internal/refopts/ref_group_builder.go
@@ -2,7 +2,6 @@ package refopts
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -21,8 +20,6 @@ type Configger interface {
 type RefGroupBuilder struct {
 	topLevelGroup *refGroup
 	groups        map[sizes.RefGroupSymbol]*refGroup
-
-	ShowRefs bool
 }
 
 // NewRefGroupBuilder creates and returns a `RefGroupBuilder`
@@ -253,8 +250,6 @@ func (rgb *RefGroupBuilder) AddRefopts(flags *pflag.FlagSet) {
 	)
 	flag.Hidden = true
 	flag.Deprecated = "use --include=@REFGROUP"
-
-	flags.BoolVar(&rgb.ShowRefs, "show-refs", false, "list the references being processed")
 }
 
 // Finish collects the information gained from processing the options
@@ -278,11 +273,6 @@ func (rgb *RefGroupBuilder) Finish() (sizes.RefGrouper, error) {
 			Name:   "Ignored",
 		}
 		refGrouper.refGroups = append(refGrouper.refGroups, *refGrouper.ignoredRefGroup)
-	}
-
-	if rgb.ShowRefs {
-		fmt.Fprintf(os.Stderr, "References (included references marked with '+'):\n")
-		return showRefGrouper{&refGrouper, os.Stderr}, nil
 	}
 
 	return &refGrouper, nil

--- a/internal/refopts/show_ref_grouper.go
+++ b/internal/refopts/show_ref_grouper.go
@@ -7,18 +7,28 @@ import (
 	"github.com/github/git-sizer/sizes"
 )
 
-// showRefFilter is a `git.ReferenceFilter` that logs its choices to Stderr.
+// showRefFilter is a `git.ReferenceFilter` that logs its choices to
+// an `io.Writer`.
 type showRefGrouper struct {
-	*refGrouper
+	sizes.RefGrouper
 	w io.Writer
 }
 
-func (refGrouper showRefGrouper) Categorize(refname string) (bool, []sizes.RefGroupSymbol) {
-	walk, symbols := refGrouper.refGrouper.Categorize(refname)
+// Return a `sizes.RefGrouper` that wraps its argument and behaves
+// like it except that it also logs its decisions to an `io.Writer`.
+func NewShowRefGrouper(rg sizes.RefGrouper, w io.Writer) sizes.RefGrouper {
+	return showRefGrouper{
+		RefGrouper: rg,
+		w:          w,
+	}
+}
+
+func (rg showRefGrouper) Categorize(refname string) (bool, []sizes.RefGroupSymbol) {
+	walk, symbols := rg.RefGrouper.Categorize(refname)
 	if walk {
-		fmt.Fprintf(refGrouper.w, "+ %s\n", refname)
+		fmt.Fprintf(rg.w, "+ %s\n", refname)
 	} else {
-		fmt.Fprintf(refGrouper.w, "  %s\n", refname)
+		fmt.Fprintf(rg.w, "  %s\n", refname)
 	}
 	return walk, symbols
 }

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -2,7 +2,7 @@ package meter
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,9 +30,10 @@ type Progress interface {
 var Spinners = []string{"|", "(", "<", "-", "<", "(", "|", ")", ">", "-", ">", ")"}
 
 // progressMeter is a `Progress` that reports the current state every
-// `period`.
+// `period` to an `io.Writer`.
 type progressMeter struct {
 	lock           sync.Mutex
+	w              io.Writer
 	format         string
 	period         time.Duration
 	lastShownCount int64
@@ -48,8 +49,9 @@ type progressMeter struct {
 // NewProgressMeter returns a progress meter that can be used to show
 // progress to a TTY periodically, including an increasing int64
 // value.
-func NewProgressMeter(period time.Duration) Progress {
+func NewProgressMeter(w io.Writer, period time.Duration) Progress {
 	return &progressMeter{
+		w:      w,
 		period: period,
 	}
 }
@@ -81,7 +83,7 @@ func (p *progressMeter) Start(format string) {
 			} else {
 				s = ""
 			}
-			fmt.Fprintf(os.Stderr, p.format, c, s, "\r")
+			fmt.Fprintf(p.w, p.format, c, s, "\r")
 			p.lock.Unlock()
 		}
 	}()
@@ -100,7 +102,7 @@ func (p *progressMeter) Done() {
 	defer p.lock.Unlock()
 	p.ticker = nil
 	c := atomic.LoadInt64(&p.count)
-	fmt.Fprintf(os.Stderr, p.format, c, " ", "\n")
+	fmt.Fprintf(p.w, p.format, c, " ", "\n")
 }
 
 // NoProgressMeter is a `Progress` that doesn't actually report

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -105,9 +105,11 @@ func (p *progressMeter) Done() {
 
 // NoProgressMeter is a `Progress` that doesn't actually report
 // anything.
-type NoProgressMeter struct{}
+var NoProgressMeter noProgressMeter
 
-func (p *NoProgressMeter) Start(string) {}
-func (p *NoProgressMeter) Inc()         {}
-func (p *NoProgressMeter) Add(int64)    {}
-func (p *NoProgressMeter) Done()        {}
+type noProgressMeter struct{}
+
+func (p noProgressMeter) Start(string) {}
+func (p noProgressMeter) Inc()         {}
+func (p noProgressMeter) Add(int64)    {}
+func (p noProgressMeter) Done()        {}

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -72,7 +72,7 @@ func ScanRepositoryUsingGraph(
 	if progress {
 		progressMeter = meter.NewProgressMeter(100 * time.Millisecond)
 	} else {
-		progressMeter = &meter.NoProgressMeter{}
+		progressMeter = meter.NoProgressMeter
 	}
 
 	refIter, err := repo.NewReferenceIter()

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sync"
-	"time"
 
 	"github.com/github/git-sizer/counts"
 	"github.com/github/git-sizer/git"
@@ -66,15 +64,10 @@ type refSeen struct {
 //
 // It returns the size data for the repository.
 func ScanRepositoryUsingGraph(
-	repo *git.Repository, rg RefGrouper, nameStyle NameStyle, progress bool,
+	repo *git.Repository, rg RefGrouper, nameStyle NameStyle,
+	progressMeter meter.Progress,
 ) (HistorySize, error) {
 	graph := NewGraph(rg, nameStyle)
-	var progressMeter meter.Progress
-	if progress {
-		progressMeter = meter.NewProgressMeter(os.Stderr, 100*time.Millisecond)
-	} else {
-		progressMeter = meter.NoProgressMeter
-	}
 
 	refIter, err := repo.NewReferenceIter()
 	if err != nil {

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -70,7 +71,7 @@ func ScanRepositoryUsingGraph(
 	graph := NewGraph(rg, nameStyle)
 	var progressMeter meter.Progress
 	if progress {
-		progressMeter = meter.NewProgressMeter(100 * time.Millisecond)
+		progressMeter = meter.NewProgressMeter(os.Stderr, 100*time.Millisecond)
 	} else {
 		progressMeter = meter.NoProgressMeter
 	}


### PR DESCRIPTION
Restructure the code so that `mainImplementation()` takes `stdout` and `stderr` parameters as `io.Writers`, and change `main()` to pass `os.Stdout` and `os.Stderr` into that function. By avoiding global variables deeper in the code, this opens the way to changing the tests to run the program in-process rather than as an external binary (but that step isn't done in this PR).

/cc @tgummerer and @ttaylorr as possible reviewers.
