### PR TITLE
test: fix tests use of 'file' protocol

### DIFF
--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -701,7 +701,7 @@ func TestSubmodule(t *testing.T) {
 	require.NoError(t, cmd.Run(), "creating main commit")
 
 	// Make subm a submodule of main:
-	cmd = mainRepo.GitCommand(t, "submodule", "add", submRepo.Path, "sub")
+	cmd = mainRepo.GitCommand(t, "-c", "protocol.file.allow=always", "submodule", "add", submRepo.Path, "sub")
 	cmd.Dir = mainRepo.Path
 	require.NoError(t, cmd.Run(), "adding submodule")
 


### PR DESCRIPTION
In response to CVE-2022-39253, Git now considers the `file://` protocol to be unsafe by default. The default value of the  `protocol.file.allow` config variable was changed to `user` [^1], meaning that a file URL or a local path is only trusted if it came directly from user input, and not if it came through a command which executes a clone/fetch/push internally.

The tests fall foul of this new requirement by attempting to run a `git submodule add` with a local directory. Internally, this performs a clone, which is no longer trusted because of the change described above. This results in the command failing with a "transport 'file' not allowed" message.

Since this is only the case for a single command, then fix the test by setting `protocol.file.allow` to `always` when we run it.

[^1]: https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253

/cc @mhagger @torstenwalter @znull