### PR TITLE
Scan starting at arbitrary roots

### DIFF
--- a/git-sizer.go
+++ b/git-sizer.go
@@ -20,7 +20,9 @@ import (
 	"github.com/github/git-sizer/sizes"
 )
 
-const usage = `usage: git-sizer [OPTS]
+const usage = `usage: git-sizer [OPTS] [ROOT...]
+
+ Scan objects in your Git repository and emit statistics about them.
 
       --threshold THRESHOLD    minimum level of concern (i.e., number of stars)
                                that should be reported. Default:
@@ -46,12 +48,29 @@ const usage = `usage: git-sizer [OPTS]
                                be set via gitconfig: 'sizer.progress'.
       --version                only report the git-sizer version number
 
+ Object selection:
+
+ git-sizer traverses through your Git history to find objects to
+ process. By default, it processes all objects that are reachable from
+ any reference. You can tell it to process only some of your
+ references; see "Reference selection" below.
+
+ If explicit ROOTs are specified on the command line, each one should
+ be a string that 'git rev-parse' can convert into a single Git object
+ ID, like 'main', 'main~:src', or an abbreviated SHA-1. See
+ git-rev-parse(1) for details. In that case, git-sizer also treats
+ those objects as starting points for its traversal, and also includes
+ the Git objects that are reachable from those roots in the analysis.
+
+ As a special case, if one or more ROOTs are specified on the command
+ line but _no_ reference selection options, then _only_ the specified
+ ROOTs are traversed, and no references.
+
  Reference selection:
 
- By default, git-sizer processes all Git objects that are reachable
- from any reference. The following options can be used to limit which
- references to process. The last rule matching a reference determines
- whether that reference is processed.
+ The following options can be used to limit which references to
+ process. The last rule matching a reference determines whether that
+ reference is processed.
 
       --[no-]branches          process [don't process] branches
       --[no-]tags              process [don't process] tags
@@ -220,10 +239,6 @@ func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []st
 		return nil
 	}
 
-	if len(flags.Args()) != 0 {
-		return errors.New("excess arguments")
-	}
-
 	if repoErr != nil {
 		return fmt.Errorf("couldn't open Git repository: %w", repoErr)
 	}
@@ -277,7 +292,7 @@ func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []st
 		progress = v
 	}
 
-	rg, err := rgb.Finish()
+	rg, err := rgb.Finish(len(flags.Args()) == 0)
 	if err != nil {
 		return err
 	}
@@ -297,8 +312,21 @@ func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []st
 		return fmt.Errorf("determining which reference to scan: %w", err)
 	}
 
+	roots := make([]sizes.Root, 0, len(refRoots)+len(flags.Args()))
+	for _, refRoot := range refRoots {
+		roots = append(roots, refRoot)
+	}
+
+	for _, arg := range flags.Args() {
+		oid, err := repo.ResolveObject(arg)
+		if err != nil {
+			return fmt.Errorf("resolving command-line argument %q: %w", arg, err)
+		}
+		roots = append(roots, sizes.NewExplicitRoot(arg, oid))
+	}
+
 	historySize, err := sizes.ScanRepositoryUsingGraph(
-		ctx, repo, refRoots, nameStyle, progressMeter,
+		ctx, repo, roots, nameStyle, progressMeter,
 	)
 	if err != nil {
 		return fmt.Errorf("error scanning repository: %w", err)

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -113,8 +113,7 @@ var ReleaseVersion string
 var BuildVersion string
 
 func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
 	err := mainImplementation(ctx, os.Stdout, os.Stderr, os.Args[1:])
 	if err != nil {

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -93,14 +94,17 @@ var ReleaseVersion string
 var BuildVersion string
 
 func main() {
-	err := mainImplementation(os.Stdout, os.Stderr, os.Args[1:])
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := mainImplementation(ctx, os.Stdout, os.Stderr, os.Args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func mainImplementation(stdout, stderr io.Writer, args []string) error {
+func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []string) error {
 	var nameStyle sizes.NameStyle = sizes.NameStyleFull
 	var cpuprofile string
 	var jsonOutput bool
@@ -288,7 +292,7 @@ func mainImplementation(stdout, stderr io.Writer, args []string) error {
 		progressMeter = meter.NewProgressMeter(stderr, 100*time.Millisecond)
 	}
 
-	historySize, err := sizes.ScanRepositoryUsingGraph(repo, rg, nameStyle, progressMeter)
+	historySize, err := sizes.ScanRepositoryUsingGraph(ctx, repo, rg, nameStyle, progressMeter)
 	if err != nil {
 		return fmt.Errorf("error scanning repository: %w", err)
 	}

--- a/git-sizer.go
+++ b/git-sizer.go
@@ -292,7 +292,14 @@ func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []st
 		progressMeter = meter.NewProgressMeter(stderr, 100*time.Millisecond)
 	}
 
-	historySize, err := sizes.ScanRepositoryUsingGraph(ctx, repo, rg, nameStyle, progressMeter)
+	refRoots, err := sizes.CollectReferences(ctx, repo, rg)
+	if err != nil {
+		return fmt.Errorf("determining which reference to scan: %w", err)
+	}
+
+	historySize, err := sizes.ScanRepositoryUsingGraph(
+		ctx, repo, refRoots, nameStyle, progressMeter,
+	)
 	if err != nil {
 		return fmt.Errorf("error scanning repository: %w", err)
 	}

--- a/git/obj_resolver.go
+++ b/git/obj_resolver.go
@@ -1,0 +1,20 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func (repo *Repository) ResolveObject(name string) (OID, error) {
+	cmd := repo.GitCommand("rev-parse", "--verify", "--end-of-options", name)
+	output, err := cmd.Output()
+	if err != nil {
+		return NullOID, fmt.Errorf("resolving object %q: %w", name, err)
+	}
+	oidString := string(bytes.TrimSpace(output))
+	oid, err := NewOID(oidString)
+	if err != nil {
+		return NullOID, fmt.Errorf("parsing output %q from 'rev-parse': %w", oidString, err)
+	}
+	return oid, nil
+}

--- a/git/ref_filter.go
+++ b/git/ref_filter.go
@@ -83,15 +83,23 @@ func (_ allReferencesFilter) Filter(_ string) bool {
 
 var AllReferencesFilter allReferencesFilter
 
+type noReferencesFilter struct{}
+
+func (_ noReferencesFilter) Filter(_ string) bool {
+	return false
+}
+
+var NoReferencesFilter noReferencesFilter
+
 // PrefixFilter returns a `ReferenceFilter` that matches references
 // whose names start with the specified `prefix`, which must match at
 // a component boundary. For example,
 //
-// * Prefix "refs/foo" matches "refs/foo" and "refs/foo/bar" but not
-//   "refs/foobar".
+//   - Prefix "refs/foo" matches "refs/foo" and "refs/foo/bar" but not
+//     "refs/foobar".
 //
-// * Prefix "refs/foo/" matches "refs/foo/bar" but not "refs/foo" or
-//   "refs/foobar".
+//   - Prefix "refs/foo/" matches "refs/foo/bar" but not "refs/foo" or
+//     "refs/foobar".
 func PrefixFilter(prefix string) ReferenceFilter {
 	if prefix == "" {
 		return AllReferencesFilter

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -563,7 +564,7 @@ func TestBomb(t *testing.T) {
 	newGitBomb(t, repo, 10, 10, "boom!\n")
 
 	h, err := sizes.ScanRepositoryUsingGraph(
-		repo.Repository(t),
+		context.Background(), repo.Repository(t),
 		refGrouper{}, sizes.NameStyleFull, meter.NoProgressMeter,
 	)
 	require.NoError(t, err)
@@ -636,7 +637,7 @@ func TestTaggedTags(t *testing.T) {
 	require.NoError(t, cmd.Run(), "creating tag 3")
 
 	h, err := sizes.ScanRepositoryUsingGraph(
-		repo.Repository(t),
+		context.Background(), repo.Repository(t),
 		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
@@ -658,7 +659,7 @@ func TestFromSubdir(t *testing.T) {
 	require.NoError(t, cmd.Run(), "creating commit")
 
 	h, err := sizes.ScanRepositoryUsingGraph(
-		repo.Repository(t),
+		context.Background(), repo.Repository(t),
 		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
@@ -711,7 +712,7 @@ func TestSubmodule(t *testing.T) {
 
 	// Analyze the main repo:
 	h, err := sizes.ScanRepositoryUsingGraph(
-		mainRepo.Repository(t),
+		context.Background(), mainRepo.Repository(t),
 		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")
@@ -724,7 +725,7 @@ func TestSubmodule(t *testing.T) {
 		Path: filepath.Join(mainRepo.Path, "sub"),
 	}
 	h, err = sizes.ScanRepositoryUsingGraph(
-		submRepo2.Repository(t),
+		context.Background(), submRepo2.Repository(t),
 		refGrouper{}, sizes.NameStyleNone, meter.NoProgressMeter,
 	)
 	require.NoError(t, err, "scanning repository")

--- a/internal/refopts/ref_group_builder.go
+++ b/internal/refopts/ref_group_builder.go
@@ -254,9 +254,14 @@ func (rgb *RefGroupBuilder) AddRefopts(flags *pflag.FlagSet) {
 
 // Finish collects the information gained from processing the options
 // and returns a `sizes.RefGrouper`.
-func (rgb *RefGroupBuilder) Finish() (sizes.RefGrouper, error) {
+func (rgb *RefGroupBuilder) Finish(defaultAll bool) (sizes.RefGrouper, error) {
 	if rgb.topLevelGroup.filter == nil {
-		rgb.topLevelGroup.filter = git.AllReferencesFilter
+		// User didn't specify any reference options.
+		if defaultAll {
+			rgb.topLevelGroup.filter = git.AllReferencesFilter
+		} else {
+			rgb.topLevelGroup.filter = git.NoReferencesFilter
+		}
 	}
 
 	refGrouper := refGrouper{

--- a/sizes/explicit_root.go
+++ b/sizes/explicit_root.go
@@ -1,0 +1,19 @@
+package sizes
+
+import "github.com/github/git-sizer/git"
+
+type ExplicitRoot struct {
+	name string
+	oid  git.OID
+}
+
+func NewExplicitRoot(name string, oid git.OID) ExplicitRoot {
+	return ExplicitRoot{
+		name: name,
+		oid:  oid,
+	}
+}
+
+func (er ExplicitRoot) Name() string { return er.name }
+func (er ExplicitRoot) OID() git.OID { return er.oid }
+func (er ExplicitRoot) Walk() bool   { return true }

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -69,7 +69,7 @@ func ScanRepositoryUsingGraph(
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	graph := NewGraph(rg, nameStyle)
+	graph := NewGraph(nameStyle)
 
 	refIter, err := repo.NewReferenceIter(ctx)
 	if err != nil {
@@ -337,8 +337,6 @@ func ScanRepositoryUsingGraph(
 
 // Graph is an object graph that is being built up.
 type Graph struct {
-	rg RefGrouper
-
 	blobLock  sync.Mutex
 	blobSizes map[git.OID]BlobSize
 
@@ -361,10 +359,8 @@ type Graph struct {
 }
 
 // NewGraph creates and returns a new `*Graph` instance.
-func NewGraph(rg RefGrouper, nameStyle NameStyle) *Graph {
+func NewGraph(nameStyle NameStyle) *Graph {
 	return &Graph{
-		rg: rg,
-
 		blobSizes: make(map[git.OID]BlobSize),
 
 		treeRecords: make(map[git.OID]*treeRecord),

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -19,12 +19,10 @@ import (
 //
 // It returns the size data for the repository.
 func ScanRepositoryUsingGraph(
+	ctx context.Context,
 	repo *git.Repository, rg RefGrouper, nameStyle NameStyle,
 	progressMeter meter.Progress,
 ) (HistorySize, error) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
 	graph := NewGraph(nameStyle)
 
 	refsSeen, err := CollectReferences(ctx, repo, rg)
@@ -32,7 +30,7 @@ func ScanRepositoryUsingGraph(
 		return HistorySize{}, fmt.Errorf("reading references: %w", err)
 	}
 
-	objIter, err := repo.NewObjectIter(context.TODO())
+	objIter, err := repo.NewObjectIter(ctx)
 	if err != nil {
 		return HistorySize{}, err
 	}

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -25,7 +25,7 @@ func ScanRepositoryUsingGraph(
 ) (HistorySize, error) {
 	graph := NewGraph(nameStyle)
 
-	refsSeen, err := CollectReferences(ctx, repo, rg)
+	refRoots, err := CollectReferences(ctx, repo, rg)
 	if err != nil {
 		return HistorySize{}, fmt.Errorf("reading references: %w", err)
 	}
@@ -42,12 +42,12 @@ func ScanRepositoryUsingGraph(
 		defer objIter.Close()
 
 		errChan <- func() error {
-			for _, refSeen := range refsSeen {
-				if !refSeen.walked {
+			for _, refRoot := range refRoots {
+				if !refRoot.Walk {
 					continue
 				}
 
-				if err := objIter.AddRoot(refSeen.OID); err != nil {
+				if err := objIter.AddRoot(refRoot.OID); err != nil {
 					return err
 				}
 			}
@@ -261,9 +261,9 @@ func ScanRepositoryUsingGraph(
 	}
 
 	progressMeter.Start("Processing references: %d")
-	for _, refSeen := range refsSeen {
+	for _, refRoot := range refRoots {
 		progressMeter.Inc()
-		graph.RegisterReference(refSeen.Reference, refSeen.walked, refSeen.groups)
+		graph.RegisterReference(refRoot.Reference, refRoot.Walk, refRoot.Groups)
 	}
 	progressMeter.Done()
 

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -20,15 +20,10 @@ import (
 // It returns the size data for the repository.
 func ScanRepositoryUsingGraph(
 	ctx context.Context,
-	repo *git.Repository, rg RefGrouper, nameStyle NameStyle,
+	repo *git.Repository, refRoots []RefRoot, nameStyle NameStyle,
 	progressMeter meter.Progress,
 ) (HistorySize, error) {
 	graph := NewGraph(nameStyle)
-
-	refRoots, err := CollectReferences(ctx, repo, rg)
-	if err != nil {
-		return HistorySize{}, fmt.Errorf("reading references: %w", err)
-	}
 
 	objIter, err := repo.NewObjectIter(ctx)
 	if err != nil {

--- a/sizes/graph.go
+++ b/sizes/graph.go
@@ -38,11 +38,11 @@ func ScanRepositoryUsingGraph(
 
 		errChan <- func() error {
 			for _, refRoot := range refRoots {
-				if !refRoot.Walk {
+				if !refRoot.Walk() {
 					continue
 				}
 
-				if err := objIter.AddRoot(refRoot.OID); err != nil {
+				if err := objIter.AddRoot(refRoot.OID()); err != nil {
 					return err
 				}
 			}
@@ -258,7 +258,7 @@ func ScanRepositoryUsingGraph(
 	progressMeter.Start("Processing references: %d")
 	for _, refRoot := range refRoots {
 		progressMeter.Inc()
-		graph.RegisterReference(refRoot.Reference, refRoot.Walk, refRoot.Groups)
+		graph.RegisterReference(refRoot.Reference(), refRoot.Walk(), refRoot.Groups())
 	}
 	progressMeter.Done()
 

--- a/sizes/grouper.go
+++ b/sizes/grouper.go
@@ -44,21 +44,21 @@ type RefGrouper interface {
 	Groups() []RefGroup
 }
 
-type refSeen struct {
+type RefRoot struct {
 	git.Reference
-	walked bool
-	groups []RefGroupSymbol
+	Walk   bool
+	Groups []RefGroupSymbol
 }
 
 func CollectReferences(
 	ctx context.Context, repo *git.Repository, rg RefGrouper,
-) ([]refSeen, error) {
+) ([]RefRoot, error) {
 	refIter, err := repo.NewReferenceIter(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var refsSeen []refSeen
+	var refsSeen []RefRoot
 	for {
 		ref, ok, err := refIter.Next()
 		if err != nil {
@@ -72,10 +72,10 @@ func CollectReferences(
 
 		refsSeen = append(
 			refsSeen,
-			refSeen{
+			RefRoot{
 				Reference: ref,
-				walked:    walk,
-				groups:    groups,
+				Walk:      walk,
+				Groups:    groups,
 			},
 		)
 	}

--- a/sizes/grouper.go
+++ b/sizes/grouper.go
@@ -50,6 +50,7 @@ type RefRoot struct {
 	groups []RefGroupSymbol
 }
 
+func (rr RefRoot) Name() string             { return rr.ref.Refname }
 func (rr RefRoot) OID() git.OID             { return rr.ref.OID }
 func (rr RefRoot) Reference() git.Reference { return rr.ref }
 func (rr RefRoot) Walk() bool               { return rr.walk }

--- a/sizes/grouper.go
+++ b/sizes/grouper.go
@@ -1,0 +1,82 @@
+package sizes
+
+import (
+	"context"
+
+	"github.com/github/git-sizer/git"
+)
+
+// RefGroupSymbol is the string "identifier" that is used to refer to
+// a refgroup, for example in the gitconfig. Nesting of refgroups is
+// inferred from their names, using "." as separator between
+// components. For example, if there are three refgroups with symbols
+// "tags", "tags.releases", and "foo.bar", then "tags.releases" is
+// considered to be nested within "tags", and "foo.bar" is considered
+// to be nested within "foo", the latter being created automatically
+// if it was not configured explicitly.
+type RefGroupSymbol string
+
+// RefGroup is a group of references, for example "branches" or
+// "tags". Reference groups might overlap.
+type RefGroup struct {
+	// Symbol is the unique string by which this `RefGroup` is
+	// identified and configured. It consists of dot-separated
+	// components, which implicitly makes a nested tree-like
+	// structure.
+	Symbol RefGroupSymbol
+
+	// Name is the name for this `ReferenceGroup` to be presented
+	// in user-readable output.
+	Name string
+}
+
+// RefGrouper describes a type that can collate reference names into
+// groups and decide which ones to walk.
+type RefGrouper interface {
+	// Categorize tells whether `refname` should be walked at all,
+	// and if so, the symbols of the reference groups to which it
+	// belongs.
+	Categorize(refname string) (bool, []RefGroupSymbol)
+
+	// Groups returns the list of `ReferenceGroup`s, in the order
+	// that they should be presented. The return value might
+	// depend on which references have been seen so far.
+	Groups() []RefGroup
+}
+
+type refSeen struct {
+	git.Reference
+	walked bool
+	groups []RefGroupSymbol
+}
+
+func CollectReferences(
+	ctx context.Context, repo *git.Repository, rg RefGrouper,
+) ([]refSeen, error) {
+	refIter, err := repo.NewReferenceIter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var refsSeen []refSeen
+	for {
+		ref, ok, err := refIter.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return refsSeen, nil
+		}
+
+		walk, groups := rg.Categorize(ref.Refname)
+
+		refsSeen = append(
+			refsSeen,
+			refSeen{
+				Reference: ref,
+				walked:    walk,
+				groups:    groups,
+			},
+		)
+	}
+}

--- a/sizes/grouper.go
+++ b/sizes/grouper.go
@@ -45,10 +45,15 @@ type RefGrouper interface {
 }
 
 type RefRoot struct {
-	git.Reference
-	Walk   bool
-	Groups []RefGroupSymbol
+	ref    git.Reference
+	walk   bool
+	groups []RefGroupSymbol
 }
+
+func (rr RefRoot) OID() git.OID             { return rr.ref.OID }
+func (rr RefRoot) Reference() git.Reference { return rr.ref }
+func (rr RefRoot) Walk() bool               { return rr.walk }
+func (rr RefRoot) Groups() []RefGroupSymbol { return rr.groups }
 
 func CollectReferences(
 	ctx context.Context, repo *git.Repository, rg RefGrouper,
@@ -73,9 +78,9 @@ func CollectReferences(
 		refsSeen = append(
 			refsSeen,
 			RefRoot{
-				Reference: ref,
-				Walk:      walk,
-				Groups:    groups,
+				ref:    ref,
+				walk:   walk,
+				groups: groups,
 			},
 		)
 	}


### PR DESCRIPTION
Have you ever wanted to compute `git-sizer` stats for a particular part of your history, for example a single tree? This PR implements that feature.

`git-sizer` now allows arbitrary ROOT argument, like

    git-sizer main^{tree}

which would show the stats for the whole source tree of the `main` commit, but for no other commits. If at least one ROOT argument is specified, then the usual behavior of scanning references doesn't happen, unless you _also_ specify options to select references, like

    git-sizer --include=refs main@{1}

which would include all references, plus the previous version of branch `main` (which might give different results if, for example, `main` just had a non-fast-forward update).

The new ROOT objects will also be used (in the form that they appeared in the command-line) in the names that are shown in the footnotes.

/cc @elhmn, @vtbassmatt
