### PR TITLE
Generate automatic draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  lint:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        uses:
+          actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build releases
+        run: |
+          make releases VERSION=$GITHUB_REF_NAME
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            releases/git-sizer-*


### PR DESCRIPTION
We needed a way to generate draft releases for git-sizer binaries.

This commit adds a new `.github/workflows/release.yml` github action that will generate a draft release when a new tag version is pushed.

the action will be triggered After the tag is created and pushed using:

```
git tag -as v$VERSION
git push origin v$VERSION
```