### PR TITLE
Cope with `safe.bare repository=explicit`

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -64,8 +64,7 @@ func NewRepository(path string) (*Repository, error) {
 	gitDir := smartJoin(path, string(bytes.TrimSpace(out)))
 
 	//nolint:gosec // `gitBin` is chosen carefully.
-	cmd = exec.Command(gitBin, "rev-parse", "--git-path", "shallow")
-	cmd.Dir = gitDir
+	cmd = exec.Command(gitBin, "--git-dir", gitDir, "rev-parse", "--git-path", "shallow")
 	out, err = cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/github/git-sizer/sizes"
 )
 
+func TestMain(m *testing.M) {
+	// Allow Git to access the bare repositories of these tests, even if
+	// the user configured `safe.bareRepository=explicit` globally.
+	os.Setenv("GIT_CONFIG_PARAMETERS", "'safe.bareRepository=all'")
+	os.Exit(m.Run())
+}
+
 func sizerExe(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
Since Git v2.38.0, [`safe.bareRepository`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safebareRepository) is a thing. When a user configures this with the value `explicit`, Git invocations will fail on bare repositories unless `GIT_DIR` is set (either explicitly or via `--git-dir`).

The tests of `git sizer` will currently fail in such a scenario because they invoke Git inside bare repositories without setting `GIT_DIR`.

A more subtle issue arises when calling `git sizer` in a non-bare repository while `safe.bareRepository=explicit` is in effect: The call to `git rev-parse --git-path shallow` is not performed in the worktree but in the Git directory. For reasons, Git treats that situation identically to being called in a bare repository, and refuses to perform the operation.

Let's fix both of these issues so that the tests pass and so that `git sizer` works as expected in user setups that have `safe.bareRepository` set to `explicit`.