### PR TITLE
Improve repository detection and deal with `safe.bareRepository=explicit`

### DIFF
--- a/git-sizer.go
+++ b/git-sizer.go
@@ -134,7 +134,7 @@ func mainImplementation(ctx context.Context, stdout, stderr io.Writer, args []st
 
 	// Try to open the repository, but it's not an error yet if this
 	// fails, because the user might only be asking for `--help`.
-	repo, repoErr := git.NewRepository(".")
+	repo, repoErr := git.NewRepositoryFromPath(".")
 
 	flags := pflag.NewFlagSet("git-sizer", pflag.ContinueOnError)
 	flags.Usage = func() {

--- a/git/git.go
+++ b/git/git.go
@@ -15,7 +15,10 @@ type ObjectType string
 
 // Repository represents a Git repository on disk.
 type Repository struct {
-	path string
+	// gitDir is the path to the `GIT_DIR` for this repository. It
+	// might be absolute or it might be relative to the current
+	// directory.
+	gitDir string
 
 	// gitBin is the path of the `git` executable that should be used
 	// when running commands in this repository.
@@ -79,7 +82,7 @@ func NewRepository(path string) (*Repository, error) {
 	}
 
 	return &Repository{
-		path:   gitDir,
+		gitDir: gitDir,
 		gitBin: gitBin,
 	}, nil
 }
@@ -103,7 +106,7 @@ func (repo *Repository) GitCommand(callerArgs ...string) *exec.Cmd {
 
 	cmd.Env = append(
 		os.Environ(),
-		"GIT_DIR="+repo.path,
+		"GIT_DIR="+repo.gitDir,
 		// Disable grafts when running our commands:
 		"GIT_GRAFT_FILE="+os.DevNull,
 	)
@@ -111,7 +114,8 @@ func (repo *Repository) GitCommand(callerArgs ...string) *exec.Cmd {
 	return cmd
 }
 
-// Path returns the path to `repo`.
-func (repo *Repository) Path() string {
-	return repo.path
+// GitDir returns the path to `repo`'s `GIT_DIR`. It might be absolute
+// or it might be relative to the current directory.
+func (repo *Repository) GitDir() string {
+	return repo.gitDir
 }

--- a/git/git.go
+++ b/git/git.go
@@ -65,10 +65,11 @@ func NewRepositoryFromGitDir(gitDir string) (*Repository, error) {
 	return &repo, nil
 }
 
-// NewRepository creates a new `Repository` object that can be used
-// for running `git` commands within `path`.
-func NewRepository(path string) (*Repository, error) {
-	// Find the `git` executable to be used:
+// NewRepositoryFromPath creates a new `Repository` object that can be
+// used for running `git` commands within `path`. It does so by asking
+// `git` what `GIT_DIR` to use. Git, in turn, bases its decision on
+// the path and the environment.
+func NewRepositoryFromPath(path string) (*Repository, error) {
 	gitBin, err := findGitBin()
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/git/git.go
+++ b/git/git.go
@@ -26,9 +26,10 @@ type Repository struct {
 	gitBin string
 }
 
-// smartJoin returns the path that can be described as `relPath`
-// relative to `path`, given that `path` is either absolute or is
-// relative to the current directory.
+// smartJoin returns `relPath` if it is an absolute path. If not, it
+// assumes that `relPath` is relative to `path`, so it joins them
+// together and returns the result. In that case, if `path` itself is
+// relative, then the return value is also relative.
 func smartJoin(path, relPath string) string {
 	if filepath.IsAbs(relPath) {
 		return relPath

--- a/git/git_bin.go
+++ b/git/git_bin.go
@@ -2,9 +2,19 @@ package git
 
 import (
 	"path/filepath"
+	"sync"
 
 	"github.com/cli/safeexec"
 )
+
+// This variable will be used to memoize the result of `findGitBin()`,
+// since its return value only depends on the environment.
+var gitBinMemo struct {
+	once sync.Once
+
+	gitBin string
+	err    error
+}
 
 // findGitBin finds the `git` binary in PATH that should be used by
 // the rest of `git-sizer`. It uses `safeexec` to find the executable,
@@ -13,15 +23,20 @@ import (
 // being scanned is hostile and non-bare because it might possibly
 // contain an executable file named `git`.
 func findGitBin() (string, error) {
-	gitBin, err := safeexec.LookPath("git")
-	if err != nil {
-		return "", err
-	}
+	gitBinMemo.once.Do(func() {
+		p, err := safeexec.LookPath("git")
+		if err != nil {
+			gitBinMemo.err = err
+			return
+		}
 
-	gitBin, err = filepath.Abs(gitBin)
-	if err != nil {
-		return "", err
-	}
+		p, err = filepath.Abs(p)
+		if err != nil {
+			gitBinMemo.err = err
+			return
+		}
 
-	return gitBin, nil
+		gitBinMemo.gitBin = p
+	})
+	return gitBinMemo.gitBin, gitBinMemo.err
 }

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -272,7 +272,10 @@ func TestRefSelections(t *testing.T) {
 				args := []string{"--show-refs", "--no-progress", "--json", "--json-version=2"}
 				args = append(args, p.args...)
 				cmd := exec.Command(executable, args...)
-				cmd.Dir = repo.Path
+				cmd.Env = append(
+					os.Environ(),
+					"GIT_DIR="+repo.Path,
+				)
 				var stdout bytes.Buffer
 				cmd.Stdout = &stdout
 				var stderr bytes.Buffer
@@ -519,7 +522,10 @@ References (included references marked with '+'):
 
 				args := append([]string{"--show-refs", "-v", "--no-progress"}, p.args...)
 				cmd := exec.Command(executable, args...)
-				cmd.Dir = repo.Path
+				cmd.Env = append(
+					os.Environ(),
+					"GIT_DIR="+repo.Path,
+				)
 				var stdout bytes.Buffer
 				cmd.Stdout = &stdout
 				var stderr bytes.Buffer

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -760,7 +759,7 @@ func TestSubmodule(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmp, err := ioutil.TempDir("", "submodule")
+	tmp, err := os.MkdirTemp("", "submodule")
 	require.NoError(t, err, "creating temporary directory")
 
 	defer func() {

--- a/internal/testutils/repoutils.go
+++ b/internal/testutils/repoutils.go
@@ -89,7 +89,7 @@ func (repo *TestRepo) Clone(t *testing.T, pattern string) *TestRepo {
 func (repo *TestRepo) Repository(t *testing.T) *git.Repository {
 	t.Helper()
 
-	r, err := git.NewRepository(repo.Path)
+	r, err := git.NewRepositoryFromPath(repo.Path)
 	require.NoError(t, err)
 	return r
 }

--- a/internal/testutils/repoutils.go
+++ b/internal/testutils/repoutils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +28,7 @@ type TestRepo struct {
 func NewTestRepo(t *testing.T, bare bool, pattern string) *TestRepo {
 	t.Helper()
 
-	path, err := ioutil.TempDir("", pattern)
+	path, err := os.MkdirTemp("", pattern)
 	require.NoError(t, err)
 
 	repo := TestRepo{Path: path}
@@ -73,7 +72,7 @@ func (repo *TestRepo) Remove(t *testing.T) {
 func (repo *TestRepo) Clone(t *testing.T, pattern string) *TestRepo {
 	t.Helper()
 
-	path, err := ioutil.TempDir("", pattern)
+	path, err := os.MkdirTemp("", pattern)
 	require.NoError(t, err)
 
 	err = repo.GitCommand(

--- a/internal/testutils/repoutils.go
+++ b/internal/testutils/repoutils.go
@@ -20,6 +20,7 @@ import (
 // TestRepo represents a git repository used for tests.
 type TestRepo struct {
 	Path string
+	bare bool
 }
 
 // NewTestRepo creates and initializes a test repository in a
@@ -37,6 +38,7 @@ func NewTestRepo(t *testing.T, bare bool, pattern string) *TestRepo {
 
 	return &TestRepo{
 		Path: path,
+		bare: bare,
 	}
 }
 
@@ -89,9 +91,15 @@ func (repo *TestRepo) Clone(t *testing.T, pattern string) *TestRepo {
 func (repo *TestRepo) Repository(t *testing.T) *git.Repository {
 	t.Helper()
 
-	r, err := git.NewRepositoryFromPath(repo.Path)
-	require.NoError(t, err)
-	return r
+	if repo.bare {
+		r, err := git.NewRepositoryFromGitDir(repo.Path)
+		require.NoError(t, err)
+		return r
+	} else {
+		r, err := git.NewRepositoryFromPath(repo.Path)
+		require.NoError(t, err)
+		return r
+	}
 }
 
 // localEnvVars is a list of the variable names that should be cleared


### PR DESCRIPTION
When reviewing #116 I noticed that repository detection was pretty confusing overall:

* ambiguous what `path` represents in various places (path where command is run, or `GIT_PATH`)
* `git rev-parse --git-path` result depends subtly on how the command is run
* detection of shallow repositories mixed up with other logic in `NewRepository()`
* `NewRepository()` always tries to deduce the `GIT_DIR`, but that is unnecessary for bare repositories

And that's in addition to the problem of dealing with `safe.bareRepository=explicit`, as explained in #116, which is also made more awkward by the fact that `git rev-parse --git-path shallow` was being invoked ad-hoc instead of through a `Repository` object.

This PR is an attempt to make things clearer. The last commit is a fix for the tests, swiped from #116 (the other commit from that PR is no longer necessary).

/cc @dscho, @elhmn 
