### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,go.sum,.codespellrc
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = fo,referers

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -36,7 +36,7 @@
                                 # return it. Creating errors with errors.New("some message") makes a magic error that no one
                                 # can handle, so either create it as a sentinel, or give it a type that people can check against.
         "goimports",        # check that all code is formatted with goimports
-                                # Formating is good. goimports is better (and formats imports slightly differently than gofmt).
+                                # Formatting is good. goimports is better (and formats imports slightly differently than gofmt).
         "gosec",            # Inspects source code for security problems
                                 # high quality linter that finds real bugs
         "govet",            # reports suspicious constructs like printf calls that don't have the right # of arguments

--- a/git/ref_iter.go
+++ b/git/ref_iter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/github/go-pipe/pipe"
 )
 
-// ReferenceIter is an iterator that interates over references.
+// ReferenceIter is an iterator that iterates over references.
 type ReferenceIter struct {
 	refCh chan Reference
 	errCh chan error

--- a/internal/refopts/filter_group_value.go
+++ b/internal/refopts/filter_group_value.go
@@ -64,7 +64,7 @@ func (f refGroupFilter) Filter(refname string) bool {
 		refGroupMatches(f.refGroup, refname)
 }
 
-// refGroupMatches retruns true iff `rg` would allow `refname`
+// refGroupMatches returns true iff `rg` would allow `refname`
 // through, not considering its parents. If `rg` doesn't have its own
 // filter, this consults its children.
 func refGroupMatches(rg *refGroup, refname string) bool {

--- a/internal/testutils/repoutils.go
+++ b/internal/testutils/repoutils.go
@@ -68,7 +68,7 @@ func (repo *TestRepo) Remove(t *testing.T) {
 	_ = os.RemoveAll(repo.Path)
 }
 
-// Clone creates a clone of `repo` at a temporary path constructued
+// Clone creates a clone of `repo` at a temporary path constructed
 // using `pattern`. The caller is responsible for removing it when
 // done by calling `Remove()`.
 func (repo *TestRepo) Clone(t *testing.T, pattern string) *TestRepo {


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.