### PR TITLE
Enable contributions from Windows developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,15 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository
-2. Configure and install the dependencies: `script/bootstrap`
-3. Make sure the tests pass on your machine: `make test`
+
+
+
+2. Configure and install the dependencies
+   - On Unix-y machines: `script/bootstrap`
+   - On Windows: `script/bootstrap.ps1` (requires PowerShell 7+) 
+3. Make sure the tests pass on your machine
+   - On Unix-y machines: `make test`
+   - On Windows machines: `make -f Makefile.win test` (because there's a different Makefile when building on Windows)
 4. Create a new branch: `git checkout -b my-branch-name`
 5. Make your change, add tests, and make sure the tests still pass
 6. Push to your fork and [submit a pull request][pr]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,10 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 
 2. Configure and install the dependencies
-   - On Unix-y machines: `script/bootstrap`
+   - On Unix-like machines: `script/bootstrap`
    - On Windows: `script/bootstrap.ps1` (requires PowerShell 7+) 
 3. Make sure the tests pass on your machine
-   - On Unix-y machines: `make test`
+   - On Unix-like machines: `make test`
    - On Windows machines: `make -f Makefile.win test` (because there's a different Makefile when building on Windows)
 4. Create a new branch: `git checkout -b my-branch-name`
 5. Make your change, add tests, and make sure the tests still pass

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,11 +5,10 @@ GO111MODULES := 1
 
 # Use the project's go wrapper script via the -File parameter to avoid loading your profile
 GOSCRIPT := $(CURDIR)/script/go.ps1
-# GOSCRIPTCORRECTED := $(shell pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "$(GOSCRIPT) -replace '/', '\'")
 GO := pwsh.exe -NoProfile -ExecutionPolicy Bypass -File $(GOSCRIPT)
 
 # Get the build version from git using try/catch instead of "||"
-BUILD_VERSION := $(shell pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "try { git describe --tags --always --dirty 2>$null } catch { Write-Output 'unknown' }")
+BUILD_VERSION := $(shell pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "try { git describe --tags --always --dirty 2>$$null } catch { Write-Output 'unknown' }")
 LDFLAGS := -X github.com/github/git-sizer/main.BuildVersion=$(BUILD_VERSION)
 GOFLAGS := -mod=readonly
 
@@ -17,16 +16,21 @@ ifdef USE_ISATTY
 GOFLAGS := $(GOFLAGS) --tags isatty
 endif
 
+# Find all Go source files
+GO_SRC_FILES := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -Path . -Filter *.go -Recurse | Select-Object -ExpandProperty FullName")
+
 # Default target
 all: bin/git-sizer.exe
 
-# Main binary target
-bin/git-sizer.exe:
+# Main binary target - depend on all Go source files
+bin/git-sizer.exe: $(GO_SRC_FILES)
 	@powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path bin)) { New-Item -ItemType Directory -Path bin | Out-Null }"
-	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o .\bin\git-sizer.exe .
+	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -a -o .\bin\git-sizer.exe .
 
-# Test target
-test: bin/git-sizer.exe gotest
+# Test target - explicitly run the build first to ensure binary is up to date
+test:
+	@$(MAKE) -f Makefile.win bin/git-sizer.exe
+	@$(MAKE) -f Makefile.win gotest
 
 # Run go tests
 gotest:
@@ -48,4 +52,3 @@ help:
 	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Example usage:' -ForegroundColor Green"
 	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win'"
 	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win test'"
-	

--- a/Makefile.win
+++ b/Makefile.win
@@ -19,12 +19,15 @@ endif
 # Find all Go source files
 GO_SRC_FILES := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -Path . -Filter *.go -Recurse | Select-Object -ExpandProperty FullName")
 
+# Define common PowerShell command
+PWSH := @powershell -NoProfile -ExecutionPolicy Bypass -Command
+
 # Default target
 all: bin/git-sizer.exe
 
 # Main binary target - depend on all Go source files
 bin/git-sizer.exe: $(GO_SRC_FILES)
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path bin)) { New-Item -ItemType Directory -Path bin | Out-Null }"
+	$(PWSH) "if (-not (Test-Path bin)) { New-Item -ItemType Directory -Path bin | Out-Null }"
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -a -o .\bin\git-sizer.exe .
 
 # Test target - explicitly run the build first to ensure binary is up to date
@@ -38,17 +41,17 @@ gotest:
 
 # Clean up builds
 clean:
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "if (Test-Path bin) { Remove-Item -Recurse -Force bin }"
+	$(PWSH) "if (Test-Path bin) { Remove-Item -Recurse -Force bin }"
 
 # Help target
 help:
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Windows Makefile for git-sizer' -ForegroundColor Cyan"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ''"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Targets:' -ForegroundColor Green"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  all        - Build git-sizer (default)'"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  test       - Run tests'"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  clean      - Clean build artifacts'"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ''"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Example usage:' -ForegroundColor Green"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win'"
-	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win test'"
+	$(PWSH) "Write-Host 'Windows Makefile for git-sizer' -ForegroundColor Cyan"
+	$(PWSH) "Write-Host ''"
+	$(PWSH) "Write-Host 'Targets:' -ForegroundColor Green"
+	$(PWSH) "Write-Host '  all        - Build git-sizer (default)'"
+	$(PWSH) "Write-Host '  test       - Run tests'"
+	$(PWSH) "Write-Host '  clean      - Clean build artifacts'"
+	$(PWSH) "Write-Host ''"
+	$(PWSH) "Write-Host 'Example usage:' -ForegroundColor Green"
+	$(PWSH) "Write-Host '  make -f Makefile.win'"
+	$(PWSH) "Write-Host '  make -f Makefile.win test'"

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,51 @@
+# Windows-specific Makefile for git-sizer designed for PowerShell
+
+PACKAGE := github.com/github/git-sizer
+GO111MODULES := 1
+
+# Use the project's go wrapper script via the -File parameter to avoid loading your profile
+GOSCRIPT := $(CURDIR)/script/go.ps1
+# GOSCRIPTCORRECTED := $(shell pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "$(GOSCRIPT) -replace '/', '\'")
+GO := pwsh.exe -NoProfile -ExecutionPolicy Bypass -File $(GOSCRIPT)
+
+# Get the build version from git using try/catch instead of "||"
+BUILD_VERSION := $(shell pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "try { git describe --tags --always --dirty 2>$null } catch { Write-Output 'unknown' }")
+LDFLAGS := -X github.com/github/git-sizer/main.BuildVersion=$(BUILD_VERSION)
+GOFLAGS := -mod=readonly
+
+ifdef USE_ISATTY
+GOFLAGS := $(GOFLAGS) --tags isatty
+endif
+
+# Default target
+all: bin/git-sizer.exe
+
+# Main binary target
+bin/git-sizer.exe:
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path bin)) { New-Item -ItemType Directory -Path bin | Out-Null }"
+	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o .\bin\git-sizer.exe .
+
+# Test target
+test: bin/git-sizer.exe gotest
+
+# Run go tests
+gotest:
+	$(GO) test -timeout 60s $(GOFLAGS) -ldflags "$(LDFLAGS)" ./...
+
+# Clean up builds
+clean:
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "if (Test-Path bin) { Remove-Item -Recurse -Force bin }"
+
+# Help target
+help:
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Windows Makefile for git-sizer' -ForegroundColor Cyan"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ''"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Targets:' -ForegroundColor Green"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  all        - Build git-sizer (default)'"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  test       - Run tests'"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  clean      - Clean build artifacts'"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ''"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host 'Example usage:' -ForegroundColor Green"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win'"
+	@powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host '  nmake -f Makefile.win test'"
+	

--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+
+# Exit immediately if any command fails
+$ErrorActionPreference = "Stop"
+
+# Change directory to the parent directory of the script
+Set-Location -Path (Split-Path -Parent $PSCommandPath | Split-Path -Parent)
+
+# Set ROOTDIR environment variable to the current directory
+$env:ROOTDIR = (Get-Location).Path
+
+# Check if the operating system is macOS
+if ($IsMacOS) {
+    brew bundle
+}
+
+# Source the ensure-go-installed.ps1 script
+. ./script/ensure-go-installed.ps1

--- a/script/ensure-go-installed.ps1
+++ b/script/ensure-go-installed.ps1
@@ -1,0 +1,64 @@
+# This script is meant to be sourced with ROOTDIR set.
+
+if (-not $env:ROOTDIR) {
+    Write-Error 'ensure-go-installed.ps1 invoked without ROOTDIR set!'
+}
+
+# Function to check if Go is installed and at least version 1.21
+function GoOk {
+    $goVersionOutput = & go version 2>$null
+    if ($goVersionOutput) {
+        $goVersion = $goVersionOutput -match 'go(\d+)\.(\d+)' | Out-Null
+        $majorVersion = [int]$Matches[1]
+        $minorVersion = [int]$Matches[2]
+        return ($majorVersion -eq 1 -and $minorVersion -ge 21)
+    }
+    return $false
+}
+
+# Function to set up a local Go installation if available
+function SetUpVendoredGo {
+    $GO_VERSION = "go1.23.7"
+    $VENDORED_GOROOT = Join-Path -Path $env:ROOTDIR -ChildPath "vendor/$GO_VERSION/go"
+    if (Test-Path -Path "$VENDORED_GOROOT/bin/go") {
+        $env:GOROOT = $VENDORED_GOROOT
+        $env:PATH = "$env:GOROOT/bin;$env:PATH"
+    }
+}
+
+# Function to check if Make is installed and install it if needed
+function EnsureMakeInstalled {
+    $makeInstalled = $null -ne (Get-Command "make" -ErrorAction SilentlyContinue)
+    if (-not $makeInstalled) {
+        #Write-Host "Installing Make using winget..."
+        winget install --no-upgrade --nowarn -e --id GnuWin32.Make 
+        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 0x8A150061) {
+            Write-Error "Failed to install Make. Please install it manually. Exit code: $LASTEXITCODE"
+        }
+        # Refresh PATH to include the newly installed Make
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    }
+
+    # Add GnuWin32 bin directory directly to the PATH
+    $gnuWin32Path = "C:\Program Files (x86)\GnuWin32\bin"
+    if (Test-Path -Path $gnuWin32Path) {
+        $env:PATH = "$gnuWin32Path;$env:PATH"
+    } else {
+        Write-Host "Couldn't find GnuWin32 bin directory at the expected location."
+        # Also refresh PATH from environment variables as a fallback
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    }    
+}
+
+SetUpVendoredGo
+
+if (-not (GoOk)) {
+    & ./script/install-vendored-go >$null
+    if ($LASTEXITCODE -ne 0) {
+        exit 1
+    }
+    SetUpVendoredGo
+}
+
+# Ensure Make is installed
+EnsureMakeInstalled

--- a/script/ensure-go-installed.ps1
+++ b/script/ensure-go-installed.ps1
@@ -1,7 +1,7 @@
 # This script is meant to be sourced with ROOTDIR set.
 
 if (-not $env:ROOTDIR) {
-    Write-Error 'ensure-go-installed.ps1 invoked without ROOTDIR set!'
+    $env:ROOTDIR = (Resolve-Path (Join-Path $scriptDir "..")).Path
 }
 
 # Function to check if Go is installed and at least version 1.21

--- a/script/go.ps1
+++ b/script/go.ps1
@@ -1,0 +1,21 @@
+# Ensure that script errors stop execution
+$ErrorActionPreference = "Stop"
+
+# Determine the root directory of the project.
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ROOTDIR = (Resolve-Path (Join-Path $scriptDir "..")).Path
+
+# Source the ensure-go-installed functionality.
+# (This assumes you have a corresponding PowerShell version of ensure-go-installed.
+#  If not, you could call the bash version via bash.exe if available.)
+$ensureScript = Join-Path $ROOTDIR "script\ensure-go-installed.ps1"
+if (Test-Path $ensureScript) {
+    . $ensureScript
+} else {
+    Write-Error "Unable to locate '$ensureScript'. Please provide a PowerShell version of ensure-go-installed."
+}
+
+# Execute the actual 'go' command with passed arguments.
+# This re-invokes the Go tool in PATH.
+$goExe = "go"
+& $goExe @args


### PR DESCRIPTION
This PR adds support for Windows developers to contribute to the project. It includes PowerShell-equivalent scripts the bash scripts that set up prerequisites and dependencies, as well as a Windows-specific Makefile that uses PowerShell to execute its steps.