### PR TITLE
Add permissions blocks to workflows that lack them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: Lint
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ on:
       - go.mod
       - go.sum
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 on: [push, pull_request]
 name: Test
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 ---
 on: [push, pull_request]
 name: Test
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
We'd like to run GitHub Actions with the least possible permissions assigned to the token for security reasons.  To make this possible, let's add a permissions block to each workflow that lacks one.

In addition, add the missing document header, since this is a best practice and yamllint warns about omitting it.

Fixes #151