### PR TITLE
Skip the SHA256 test if git has not support for it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.17'
+          go-version: '1.21.3'
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -869,7 +869,7 @@ func TestSHA256(t *testing.T) {
 	cmd.Env = testutils.CleanGitEnv()
 	output, err := cmd.CombinedOutput()
 
-	if err != nil && strings.HasPrefix(string(output), "error: unknown option `object-format'") {
+	if err != nil && strings.Contains(string(output), "object-format") {
 		t.Skip("skipping due to lack of SHA256 support")
 	}
 	require.NoError(t, err)

--- a/git_sizer_test.go
+++ b/git_sizer_test.go
@@ -867,7 +867,11 @@ func TestSHA256(t *testing.T) {
 	// exist yet:
 	cmd := exec.Command("git", "init", "--object-format", "sha256", testRepo.Path)
 	cmd.Env = testutils.CleanGitEnv()
-	err = cmd.Run()
+	output, err := cmd.CombinedOutput()
+
+	if err != nil && strings.HasPrefix(string(output), "error: unknown option `object-format'") {
+		t.Skip("skipping due to lack of SHA256 support")
+	}
 	require.NoError(t, err)
 
 	timestamp := time.Unix(1112911993, 0)


### PR DESCRIPTION
If you are building and running the tests in an environment with an older version of git, it might not have SHA256 support. This should not cause the git-sizer test suite to fail as it's not an issue with git-sizer.

Detect this situation and skip the test.